### PR TITLE
Add OpenTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,8 +646,8 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 
 - [appdash](https://github.com/sourcegraph/appdash) - Application tracing system for Go, based on Google's Dapper.
 - [jaeger](https://github.com/jaegertracing/jaeger) - Jaeger, a Distributed Tracing System.
-- [opentelemetry](https://github.com/open-telemetry/opentelemetry-specification) - An observability framework for cloud-native software.
 - [opencensus](https://github.com/census-instrumentation) - A single distribution of libraries that automatically collect traces and metrics from your app, display them locally, and send them to any backend.
+- [opentelemetry](https://github.com/open-telemetry/opentelemetry-specification) - An observability framework for cloud-native software.
 - [opentracing](https://github.com/opentracing) - Consistent, expressive, vendor-neutral APIs for distributed tracing and context propagation.
 - [pinpoint](https://github.com/naver/pinpoint) - Pinpoint is an open source APM (Application Performance Management) tool for large-scale distributed systems written in Java.
 - [sentry](https://github.com/getsentry/sentry) - Sentry is a cross-platform crash reporting and aggregation platform.

--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 
 - [appdash](https://github.com/sourcegraph/appdash) - Application tracing system for Go, based on Google's Dapper.
 - [jaeger](https://github.com/jaegertracing/jaeger) - Jaeger, a Distributed Tracing System.
+- [opentelemetry](https://github.com/open-telemetry/opentelemetry-specification) - An observability framework for cloud-native software.
 - [opencensus](https://github.com/census-instrumentation) - A single distribution of libraries that automatically collect traces and metrics from your app, display them locally, and send them to any backend.
 - [opentracing](https://github.com/opentracing) - Consistent, expressive, vendor-neutral APIs for distributed tracing and context propagation.
 - [pinpoint](https://github.com/naver/pinpoint) - Pinpoint is an open source APM (Application Performance Management) tool for large-scale distributed systems written in Java.


### PR DESCRIPTION
Add OpenTelemetry.

I am using this URL https://github.com/open-telemetry currently because they have many libraries for different languages at different repos under this org. So I don't know which exact repo should be used.

Or should we use their website repo https://github.com/open-telemetry/opentelemetry.io ? If need change to this, I can update.