### PR TITLE
Add Firezone to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [eksctl](https://github.com/weaveworks/eksctl) - A CLI for Amazon EKS.
 - [erda](https://github.com/erda-project/erda) - An enterprise-grade application building, deploying, monitoring platform (An iPaaS).
 - [escalator](https://github.com/atlassian/escalator) - Escalator is a batch or job optimized horizontal autoscaler for Kubernetes.
+- [firezone](https://github.com/firezone/firezone) - VPN server and Linux firewall built on WireGuard®. Supports SSO, MFA, and user-scoped access rules.
 - [fleet](https://github.com/rancher/fleet) - Manage large fleets of Kubernetes clusters.
 - [freshpod](https://github.com/googlecloudplatform/freshpod) - Restart Pods on Minikube automatically on image rebuilds.
 - [fubectl](https://github.com/kubermatic/fubectl) - Reduces repetitive interactions with kubectl.


### PR DESCRIPTION
Added Firezone (https://github.com/firezone/firezone) to tools. The project is actively maintained and has decent docs (https://docs.firezone.dev/).