### PR TITLE
Add keyenv to Security & Compliance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,7 +809,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [infra](https://github.com/infrahq/infra) - Infra provides authentication and access management to servers and Kubernetes clusters.
 - [k8guard](https://github.com/k8guard) - An auditing system for Kubernetes.
 - [kamus](https://github.com/Soluto/kamus) - An open source, git-ops, zero-trust secret encryption and decryption solution for Kubernetes applications.
-- [keyenv](https://github.com/keyenv/keyenv) - CLI-first secrets manager that replaces .env files with encrypted, team-shared environment variables using AES-256-GCM. Supports runtime injection and role-based access control.
+- [keyenv](https://keyenv.dev) - CLI-first secrets manager that replaces .env files with encrypted, team-shared environment variables using AES-256-GCM. Supports runtime injection and role-based access control.
 - [keycloak](https://github.com/keycloak/keycloak) - Open Source Identity and Access Management For Modern Applications and Services.
 - [kratos](https://github.com/ory/kratos) - Next-gen identity server (think Auth0, Okta, Firebase) with Ory-hardened authentication, MFA, FIDO2, profile management, identity schemas, social sign in, registration, account recovery, service-to-service and IoT auth. Can work as an OAuth2 / OpenID Connect Provider. Golang, headless, API-only - without templating or theming headaches.
 - [kritis](https://github.com/grafeas/kritis) - Deploy-time Policy Enforcer for Kubernetes applications.

--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [infra](https://github.com/infrahq/infra) - Infra provides authentication and access management to servers and Kubernetes clusters.
 - [k8guard](https://github.com/k8guard) - An auditing system for Kubernetes.
 - [kamus](https://github.com/Soluto/kamus) - An open source, git-ops, zero-trust secret encryption and decryption solution for Kubernetes applications.
+- [keyenv](https://github.com/keyenv/keyenv) - CLI-first secrets manager that replaces .env files with encrypted, team-shared environment variables using AES-256-GCM. Supports runtime injection and role-based access control.
 - [keycloak](https://github.com/keycloak/keycloak) - Open Source Identity and Access Management For Modern Applications and Services.
 - [kratos](https://github.com/ory/kratos) - Next-gen identity server (think Auth0, Okta, Firebase) with Ory-hardened authentication, MFA, FIDO2, profile management, identity schemas, social sign in, registration, account recovery, service-to-service and IoT auth. Can work as an OAuth2 / OpenID Connect Provider. Golang, headless, API-only - without templating or theming headaches.
 - [kritis](https://github.com/grafeas/kritis) - Deploy-time Policy Enforcer for Kubernetes applications.


### PR DESCRIPTION
## What is KeyEnv?

[KeyEnv](https://keyenv.dev) is a CLI-first secrets manager that replaces `.env` files with encrypted, team-shared environment variables using AES-256-GCM. It supports runtime injection and role-based access control.

- **Website:** https://keyenv.dev
- **Section:** Security & Compliance (alongside external-secrets, kamus, vault-secrets-operator)

KeyEnv fits naturally alongside the existing secrets management tools in this section, providing a lightweight CLI alternative to heavier solutions like Vault for cloud-native teams.