### PR TITLE
Add Ingero - eBPF-based GPU causal observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [grafana](https://github.com/grafana/grafana) - The tool for beautiful monitoring and metric analytics & dashboards for Graphite, InfluxDB & Prometheus & More.
 - [hawkular-metrics](https://github.com/hawkular/hawkular-metrics) - Time Series Metrics Engine based on Cassandra.
 - [highlight](https://github.com/highlight/highlight) - The open source, full-stack monitoring platform. Error monitoring, session replay, logging and more.
-- [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent. Traces CUDA APIs and host kernel events to explain GPU latency in cloud-native environments. Helm chart and DaemonSet included.
+- [ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent. Traces CUDA APIs and host kernel events to explain GPU latency in cloud-native environments. Helm chart and DaemonSet included.
 - [inspektor-gadget](https://github.com/inspektor-gadget/inspektor-gadget) - The eBPF tool and systems inspection framework for Kubernetes, containers and Linux hosts.
 - [istio-ui](https://github.com/jukylin/istio-ui) - Istio config management backend.
 - [kelemetry](https://github.com/kubewharf/kelemetry) - Global control plane tracing for Kubernetes.

--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [grafana](https://github.com/grafana/grafana) - The tool for beautiful monitoring and metric analytics & dashboards for Graphite, InfluxDB & Prometheus & More.
 - [hawkular-metrics](https://github.com/hawkular/hawkular-metrics) - Time Series Metrics Engine based on Cassandra.
 - [highlight](https://github.com/highlight/highlight) - The open source, full-stack monitoring platform. Error monitoring, session replay, logging and more.
+- [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent. Traces CUDA APIs and host kernel events to explain GPU latency in cloud-native environments. Helm chart and DaemonSet included.
 - [inspektor-gadget](https://github.com/inspektor-gadget/inspektor-gadget) - The eBPF tool and systems inspection framework for Kubernetes, containers and Linux hosts.
 - [istio-ui](https://github.com/jukylin/istio-ui) - Istio config management backend.
 - [kelemetry](https://github.com/kubewharf/kelemetry) - Global control plane tracing for Kubernetes.


### PR DESCRIPTION
## Summary

Adds [Ingero](https://github.com/ingero-io/ingero) to the **Observability & Monitoring** section.

Ingero is an open-source, eBPF-based GPU causal observability agent. It traces CUDA Runtime and Driver APIs via kernel uprobes plus host OS events (CPU scheduling, memory, process lifecycle) via tracepoints to build causal chains explaining GPU latency. Designed for production use with <2% overhead.

**Cloud-native support:**
- Helm chart and DaemonSet for Kubernetes deployment
- Container/pod metadata enrichment (namespace, pod name, container ID)
- Auto-discovery of GPU pods via `nvidia.com/gpu` resource requests
- OTLP and Prometheus export

**Key details:**
- Language: Go + eBPF C
- License: Apache 2.0 (Go) / GPL-2.0 OR BSD-3-Clause (eBPF)
- No dependencies on NVIDIA CUPTI or proprietary tooling
- MCP server for AI-assisted GPU debugging