### PR TITLE
Add cloud-audit to Security & Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [cedar](https://github.com/cedar-policy/cedar) - Core implementation of the Cedar language.
 - [cert-manager](https://github.com/jetstack/cert-manager) - Automatically provision and manage TLS certificates in Kubernetes.
 - [checkov](https://github.com/bridgecrewio/checkov/) - A static analysis tool for infrastructure as code - to prevent misconfigs at build time.
+- [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - Fast, opinionated AWS security scanner with 47 curated checks. Each finding includes copy-paste remediation in AWS CLI and Terraform. Features attack chain detection and a diff command for CI/CD pipeline gating.
 - [clair](https://github.com/quay/clair) - Vulnerability Static Analysis for Containers.
 - [coraza](https://github.com/corazawaf/coraza) - OWASP Coraza WAF is a golang modsecurity compatible web application firewall library.
 - [cosign](https://github.com/sigstore/cosign) - Container signing, verification, and provenance powered by Sigstore.


### PR DESCRIPTION
Adds [cloud-audit](https://github.com/gebalamariusz/cloud-audit) to the Security & Compliance section.

cloud-audit is a fast, opinionated AWS security scanner with:
- 47 curated checks (IAM, S3, EC2, RDS, VPC, Lambda, KMS, Secrets Manager)
- Copy-paste remediation in AWS CLI and Terraform for every finding
- Attack chain detection - correlates findings into exploitable multi-step paths
- Diff command for tracking changes between scans
- SARIF output for GitHub Code Scanning
- GitHub Actions Marketplace integration
- MIT license, Python CLI

Placed alphabetically after `checkov` in the Security & Compliance section.