### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims) - Containerd shims for running WebAssembly workloads in Kubernetes.
 - [cri-o](https://github.com/cri-o/cri-o) - Open Container Initiative-based implementation of Kubernetes Container Runtime Interface.
 - [crun](https://github.com/containers/crun) - A fast and lightweight fully featured OCI runtime and C library for running containers.
+- [den](https://github.com/us/den) - Self-hosted sandbox runtime for AI agents with isolated Docker containers, cgroup v2 memory management, and dynamic pressure monitoring.
 - [firecracker-containerd](https://github.com/firecracker-microvm/firecracker-containerd) - firecracker-containerd enables containerd to manage containers as Firecracker microVMs.
 - [frakti](https://github.com/kubernetes/frakti) - The hypervisor-based container runtime for Kubernetes.
 - [gvisor](https://github.com/google/gvisor) - Sandboxed Container Runtime.

--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [kubernetes-lts](https://github.com/klts-io/kubernetes-lts) - Kubernetes LTS(long term support).
 - [lima](https://github.com/AkihiroSuda/lima) - Linux virtual machines, on macOS (aka "Linux-on-Mac", "macOS subsystem for Linux", "containerd for Mac", unofficially).
 - [moby](https://github.com/moby/moby) - Moby Project - a collaborative project for the container ecosystem to assemble container-based systems.
+- [mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework.
 - [podman](https://github.com/containers/podman) - A tool for managing OCI containers and pods.
 - [pouch](https://github.com/alibaba/pouch) - Pouch is an open-source project created to promote the container technology movement.
 - [railcar](https://github.com/oracle/railcar) - RailCar: Rust implementation of the Open Containers Initiative oci-runtime.


### PR DESCRIPTION
[Mocker](https://github.com/us/mocker) is a Docker-compatible container CLI for macOS, built natively on Apple's Containerization framework.

- **Language:** Swift
- **License:** AGPL-3.0
- **Platform:** macOS (Apple Silicon)

Mocker provides full Docker CLI compatibility (111 commands) including `docker run`, `docker build`, `docker compose`, and more — all running natively on macOS without a Linux VM for the CLI layer.

Added alphabetically under the **Runtimes & Platforms** section.