### PR TITLE
feat: add KubeStellar Console to Dashboards & Portals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [marathon](https://github.com/mesosphere/marathon) - Deploy and manage containers (including Docker) on top of Apache Mesos at scale.
 - [mesos](https://github.com/apache/mesos) - Apache Mesos abstracts CPU, memory, storage, and other compute resources away from machines (physical or virtual), enabling fault-tolerant and elastic distributed systems to easily be built and run effectively.
 - [ocm](https://github.com/open-cluster-management-io/OCM) - The open-cluster-management.io project is focused on enabling end-to-end visibility and control across your Kubernetes clusters.
+- [kubestellar-console](https://github.com/kubestellar/console) - CNCF Sandbox multi-cluster Kubernetes management dashboard with AI-powered operations, real-time observability, and guided CNCF project deployments across edge and cloud clusters.
 - [serf](https://github.com/hashicorp/serf) - Service orchestration and management tool by hashicorp.
 - [service-fabric](https://github.com/Microsoft/service-fabric) - Service Fabric is a distributed systems platform for packaging, deploying, and managing stateless and stateful distributed applications and containers at large scale.
 - [supergiant](https://github.com/supergiant/control) - Automatically scale hardware and easily run stateful applications using Kubernetes.


### PR DESCRIPTION
## What

Adds **KubeStellar Console** to the Dashboards & Portals section, in alphabetical order between `kubesphere` and `kubevious`.

## Why

KubeStellar Console is an AI-powered multi-cluster Kubernetes dashboard — a CNCF Sandbox project that fits naturally in this section alongside KubeSphere and Rancher. Key differentiators:

- Multi-cluster management across edge, cloud, and hybrid environments
- AI/LLM-powered operations and natural language queries
- Real-time observability with integrations for Argo, Kyverno, Istio, and 20+ CNCF projects
- GitHub: https://github.com/kubestellar/console
- Live demo: https://console.kubestellar.io

## Entry added

```markdown
- [kubestellar-console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with real-time observability and CNCF project integrations.
```