### PR TITLE
Add Radar to Dashboards & Portals

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,6 +888,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [opendcp](https://github.com/weibocom/opendcp) - Docker platform developed by weibo.
 - [openshift](https://github.com/openshift/origin) - Enterprise Kubernetes for Developers.
 - [portainer](https://github.com/portainer/portainer) - Simple management UI for Docker.
+- [radar](https://github.com/skyhook-io/radar) - Modern Kubernetes visibility tool with multi-cluster topology, image filesystem viewer, Helm and GitOps management, and built-in MCP server.
 - [rainbond](https://github.com/goodrain/rainbond) - Serverless PaaS , A new generation of easy-to-use cloud management platforms based on kubernetes.
 - [rancher](https://github.com/rancher/rancher) - Complete container management platform.
 - [statusbay](https://github.com/similarweb/statusbay) - Kubernetes deployment visibility like a pro.


### PR DESCRIPTION
Adds [Radar](https://github.com/skyhook-io/radar) to the Dashboards & Portals section (alphabetical position between portainer and rainbond).

Modern open-source Kubernetes visibility tool. Single binary with multi-cluster topology, image filesystem viewer, Helm and GitOps management (FluxCD/ArgoCD), and a built-in MCP server for AI agents. No agents, no cloud dependency.

⭐ 1,300+ stars · 17+ contributors · Apache-2.0 · [radarhq.io](https://radarhq.io)