### PR TITLE
Add agenttier to Kubernetes Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 
 ## Kubernetes Operators
 
+- [agenttier](https://github.com/agenttier/agenttier) - Kubernetes-native operator that manages isolated, persistent sandboxes for human developers and AI agents through Sandbox CRDs, with built-in governance, warm-pod pool, and a streaming agent-mode REST API.
 - [banzaicloud/bank-vaults](https://github.com/banzaicloud/bank-vaults) - A Vault swiss-army knife: a K8s operator, Go client with automatic token renewal, automatic configuration, multiple unseal options and more. A CLI tool to init, unseal and configure Vault (auth methods, secret engines). Direct secret injection into Pods.
 - [eunomia](https://github.com/KohlsTechnology/eunomia) - A GitOps Operator for Kubernetes.
 - [fabedge](https://github.com/FabEdge/fabedge) - Secure Edge Networking Based On Kubernetes And KubeEdge.


### PR DESCRIPTION
This PR adds [agenttier](https://github.com/agenttier/agenttier) as a new entry in the **Kubernetes Operators** section.

Why it fits this list: AgentTier is a kubebuilder-built Kubernetes operator (Apache-2.0). It reconciles three CRDs under agenttier.io/v1alpha1 (Sandbox, SandboxTemplate, ClusterSandboxTemplate) to manage isolated, persistent sandboxes for both human developers and AI agents — Pod + PVC + NetworkPolicy + per-session ServiceAccount per sandbox, with optional gVisor for kernel isolation. Sandboxes can run in mode: code (interactive browser terminal) or mode: agent (REST /configure + SSE-streaming /invoke).

Compliance with CONTRIBUTING.md:

- Open source (Apache-2.0), GitHub-hosted, cloud-native.
- Single best-matching category — Kubernetes Operators.
- Single-line description, sentence case, no marketing fluff.
- Alphabetical placement: agenttier sorts before banzaicloud/bank-vaults, so the entry goes at the top of the list.
- Local checks run on the changed section:
  - go test ./... — TestAlpha/Kubernetes_Operators passes; the only pre-existing failures (Continuous_Delivery_GitOps and Security_Compliance) are unrelated to this PR and exist on main before my change.
  - go run ./repo.go — runs cleanly. I have not committed the regenerated tmpl/index.html because the most recent merged PRs (#108, #110, #111, #114, #116, #119) all touched only README.md; appears the maintainer regenerates the static site themselves. Happy to add it if preferred.
  - gofmt -w — not needed (no Go files modified).

The diff is a single-line addition.
