### PR TITLE
Add k100s

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [cloudfoundry](https://github.com/cloudfoundry) - Cloud Foundry is an open source, multi cloud application platform as a service (PaaS) governed by the Cloud Foundry Foundation.
 - [conjure-up](https://github.com/conjure-up/conjure-up) - Deploying complex solutions, magically.
 - [dashboard](https://github.com/kubernetes/dashboard) - General-purpose web UI for Kubernetes clusters.
+- [k100s](https://github.com/AndrewVos/k100s) - Free, open-source desktop Kubernetes app for browsing pods, streaming logs, and opening pod shells.
 - [karpor](https://github.com/KusionStack/karpor) - Intelligence for Kubernetes. World's most promising Kubernetes Visualization Tool for Developer and Platform Engineering teams.
 - [kdash](https://github.com/kdash-rs/kdash) - A simple and fast dashboard for Kubernetes.
 - [kqeen](https://github.com/Mirantis/kqueen) - Kubernetes queen - cluster manager.

--- a/tmpl/index.html
+++ b/tmpl/index.html
@@ -121,7 +121,6 @@ API Gateways &amp; Proxies</h2>
 <li><a href="https://github.com/nginxinc/nginx-gateway-fabric" rel="nofollow">nginx-gateway-fabric</a> - NGINX Gateway Fabric provides an implementation for the Gateway API using NGINX as the data plane.</li>
 <li><a href="https://github.com/ThreeMammals/Ocelot" rel="nofollow">ocelot</a> - .NET core API Gateway.</li>
 <li><a href="https://github.com/orlabs/orange" rel="nofollow">orange</a> - OpenResty/Nginx Gateway for API Monitoring and Management.</li>
-<li><a href="https://github.com/soapbucket/sbproxy" rel="nofollow">sbproxy</a> - Single-binary AI gateway and reverse proxy with 103+ LLM providers, cost-based routing, rate limiting, and declarative YAML configuration.</li>
 <li><a href="https://github.com/TykTechnologies/tyk" rel="nofollow">tyk</a> - Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols.</li>
 </ul>
 <h2><a name="continuous-delivery-gitops" class="anchor" href="#continuous-delivery-gitops" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
@@ -213,7 +212,6 @@ Continuous Delivery &amp; GitOps</h2>
 <li><a href="https://github.com/banzaicloud/pipeline" rel="nofollow">pipeline</a> - REST API to provision or reuse managed Kubernetes clusters in the cloud and deploy cloud native apps.</li>
 <li><a href="https://github.com/tektoncd/pipeline" rel="nofollow">pipeline</a> - A cloud-native Pipeline resource.</li>
 <li><a href="https://github.com/pulumi/pulumi" rel="nofollow">pulumi</a> - A multi-language, multi-cloud development platform -- your code, your cloud, your team.</li>
-<li><a href="https://github.com/Qovery/qovery-skills" rel="nofollow">qovery</a> - Enterprise Kubernetes management platform for deploying applications, databases, Helm charts, and Terraform modules on AWS, GCP, Azure, and Scaleway. Includes Terraform provider, CLI, API, and AI Agent Skill.</li>
 <li><a href="https://github.com/splunk/qbec" rel="nofollow">qbec</a> - Configure kubernetes objects on multiple clusters using jsonnet.</li>
 <li><a href="https://github.com/radius-project/radius" rel="nofollow">radius</a> - Radius is a cloud-native, portable application platform that makes app development easier for teams building cloud-native apps.</li>
 <li><a href="https://github.com/screwdriver-cd/screwdriver" rel="nofollow">screwdriver</a> - An open source build platform designed for continuous delivery.</li>
@@ -271,7 +269,6 @@ Configuration &amp; Policy Automation</h2>
 <li><a href="https://github.com/open-feature/spec" rel="nofollow">openfeature</a> - Vendor-neutral feature flag standard and SDKs for cloud native apps.</li>
 <li><a href="https://github.com/FairwindsOps/pluto" rel="nofollow">pluto</a> - A cli tool to help discover deprecated apiVersions in Kubernetes.</li>
 <li><a href="https://github.com/stakater/Reloader" rel="nofollow">reloader</a> - A Kubernetes controller to watch changes in ConfigMap and Secrets and do rolling upgrades on Pods with their associated Deployment, StatefulSet, DaemonSet and DeploymentConfig.</li>
-<li><a href="https://github.com/Unleash/unleash" rel="nofollow">unleash</a> - Open-source feature management platform to decouple deploy from release and enable continuous delivery safely.</li>
 </ul>
 <h2><a name="cluster-provisioning-lifecycle" class="anchor" href="#cluster-provisioning-lifecycle" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Cluster Provisioning &amp; Lifecycle</h2>
@@ -368,7 +365,6 @@ Diagnostics &amp; Troubleshooting</h2>
 <li><a href="https://github.com/mr-karan/kubekutr" rel="nofollow">kubeutr</a> - Cookie cutter templating tool for scaffolding K8s manifests.</li>
 <li><a href="https://github.com/memfreeme/memfree" rel="nofollow">memfree</a> - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs. Support One-Click Deployment.</li>
 <li><a href="https://github.com/dpeckett/pangolin" rel="nofollow">pangolin</a> - An enhanced Horizontal Pod Autoscaler for Kubernetes.</li>
-<li><a href="https://github.com/Releaserun/releaserun-cli" rel="nofollow">releaserun-cli</a> - CLI tool to check Kubernetes manifests for deprecated/removed APIs, scan dependencies for vulnerabilities, and track version lifecycle status.</li>
 <li><a href="https://github.com/robusta-dev/robusta" rel="nofollow">robusta</a> - Open source Kubernetes troubleshooting and automation platform.</li>
 <li><a href="https://github.com/solo-io/squash" rel="nofollow">squash</a> - The debugger for microservices.</li>
 <li><a href="https://github.com/wercker/stern" rel="nofollow">stern</a> - Multi pod and container log tailing for Kubernetes.</li>
@@ -396,7 +392,6 @@ Data Protection &amp; Backup</h2>
 Cost &amp; Governance</h2>
 
 <ul>
-<li><a href="https://github.com/tanrikuluozlem/burn" rel="nofollow">burn</a> - CLI tool for Kubernetes cost analysis with per-namespace breakdown, real cloud pricing, and AI-powered recommendations.</li>
 <li><a href="https://github.com/kubecost/cost-model" rel="nofollow">cost-model</a> - Cross-cloud cost allocation models for workloads running on Kubernetes.</li>
 <li><a href="https://github.com/atlassian/escalator" rel="nofollow">escalator</a> - Escalator is a batch or job optimized horizontal autoscaler for Kubernetes.</li>
 <li><a href="https://github.com/aws/karpenter" rel="nofollow">karpenter</a> - Kubernetes Node Autoscaling: built for flexibility, performance, and scalability.</li>
@@ -468,61 +463,33 @@ Databases</h2>
 Storage &amp; Data Management</h2>
 
 <ul>
-<li><p><a href="https://github.com/mixpeek/awesome-object-storage" rel="nofollow">awesome-object-storage</a> - Curated comparison of 21 S3-compatible object storage providers with pricing, gotchas, and tools.</p></li>
-
-<li><p><a href="https://github.com/ceph/ceph" rel="nofollow">ceph</a> - Ceph is a distributed object, block, and file storage platform.</p></li>
-
-<li><p><a href="https://github.com/chubaofs/chubaofs" rel="nofollow">chubaofs</a> - A distributed storage system for cloud native applications.</p></li>
-
-<li><p><a href="https://github.com/rancher/convoy" rel="nofollow">convoy</a> - A Docker volume plugin, managing persistent container volumes.</p></li>
-
-<li><p><a href="https://github.com/opencurve/curve" rel="nofollow">curve</a> - Curve is a better-used cloud-native SDS storage system, featured with high performance, easy operation, cloud native. Curve is composed with CurveBS and CurveFS based on Raft.</p></li>
-
-<li><p><a href="https://github.com/happyfish100/fastdfs" rel="nofollow">fastdfs</a> - FastDFS is an open source high performance distributed file system (DFS). It&#39;s major functions include: file storing, file syncing and file accessing, and design for high capacity and load balance.</p></li>
-
-<li><p><a href="https://github.com/ClusterHQ/flocker" rel="nofollow">flocker</a> - Container data volume manager for your Dockerized application.</p></li>
-
-<li><p><a href="https://github.com/gluster/glusterd2" rel="nofollow">glusterd2</a> - GlusterD-2.0 is the distributed management framework to be used for GlusterFS-4.0.</p></li>
-
-<li><p><a href="https://github.com/gluster/glusterfs" rel="nofollow">glusterfs</a> - Gluster is a software defined distributed storage that can scale to several petabytes. It provides interfaces for object, block and file storage.</p></li>
-
-<li><p><a href="https://github.com/goharbor/harbor" rel="nofollow">harbor</a> - An open source trusted cloud native registry project that stores, signs, and scans content.</p></li>
-
-<li><p><a href="https://github.com/heketi/heketi" rel="nofollow">heketi</a> - RESTful based volume management framework for GlusterFS.</p></li>
-
-<li><p><a href="https://github.com/hwameistor/hwameistor" rel="nofollow">hwameistor</a> - Hwameistor is an HA local storage system for cloud-native stateful workloads.</p></li>
-
-<li><p><a href="https://github.com/infinit/infinit" rel="nofollow">infinit</a> - The Infinit policy-based software-defined storage platform.</p></li>
-
-<li><p><a href="https://github.com/juicedata/juicefs" rel="nofollow">juicefs</a> - A distributed POSIX file system built on top of Redis and S3.</p></li>
-
-<li><p><a href="https://github.com/k8ssandra/k8ssandra" rel="nofollow">k8ssandra</a> - K8ssandra is a collection of Helm charts for running Apache Cassandra on Kubernetes in production.</p></li>
-
-<li><p><a href="https://github.com/configurator/kubefs" rel="nofollow">kubefs</a> - Mount kubernetes metadata storage as a filesystem.</p></li>
-
-<li><p><a href="https://leo-project.net/leofs/" rel="nofollow">leofs</a> - The LeoFS Storage System.</p></li>
-
-<li><p><a href="https://github.com/longhorn/longhorn" rel="nofollow">longhorn</a> - We put storage on cows and move them around from rancher.</p></li>
-
-<li><p><a href="https://github.com/minio/minio" rel="nofollow">minio</a> - Minio is an open source object storage server compatible with Amazon S3 APIs.</p></li>
-
-<li><p><a href="https://github.com/openebs/openebs" rel="nofollow">openebs</a> - OpenEBS is containerized block storage written in Go for cloud native and other environments w/ per container (or pod) QoS SLAs, tiering and replica policies across AZs and environments, and predictable and scalable performance.</p></li>
-
-<li><p><a href="https://github.com/oras-project/oras" rel="nofollow">oras</a> - OCI registry client, managing content like artifacts, images, packages.</p></li>
-
-<li><p><a href="https://github.com/kyma-project/rafter" rel="nofollow">rafter</a> - Kubernetes-native S3-like files/assets store based on CRDs and powered by MinIO.</p></li>
-
-<li><p><a href="https://github.com/rook/rook" rel="nofollow">rook</a> - File, Block, and Object Storage Services for your Cloud-Native Environment.</p></li>
-
-<li><p><a href="https://storageos.com/" rel="nofollow">storageos</a> - Enterprise persistent storage for containers and the cloud.</p></li>
-
-<li><p><a href="https://github.com/coreos/torus" rel="nofollow">torus</a> - Torus Distributed Storage.</p></li>
-
-<li><p><a href="https://github.com/vitessio/vitess" rel="nofollow">vitess</a> - Vitess is a database clustering system for horizontal scaling of MySQL.</p></li>
-
-<li><p><a href="https://github.com/scality/Zenko" rel="nofollow">zenko</a> - Because everyone should be in control of their data.</p></li>
-
-<li><p><a href="https://github.com/project-zot/zot" rel="nofollow">zot</a> - A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification).</p></li>
+<li><a href="https://github.com/ceph/ceph" rel="nofollow">ceph</a> - Ceph is a distributed object, block, and file storage platform.</li>
+<li><a href="https://github.com/chubaofs/chubaofs" rel="nofollow">chubaofs</a> - A distributed storage system for cloud native applications.</li>
+<li><a href="https://github.com/rancher/convoy" rel="nofollow">convoy</a> - A Docker volume plugin, managing persistent container volumes.</li>
+<li><a href="https://github.com/opencurve/curve" rel="nofollow">curve</a> - Curve is a better-used cloud-native SDS storage system, featured with high performance, easy operation, cloud native. Curve is composed with CurveBS and CurveFS based on Raft.</li>
+<li><a href="https://github.com/happyfish100/fastdfs" rel="nofollow">fastdfs</a> - FastDFS is an open source high performance distributed file system (DFS). It&#39;s major functions include: file storing, file syncing and file accessing, and design for high capacity and load balance.</li>
+<li><a href="https://github.com/ClusterHQ/flocker" rel="nofollow">flocker</a> - Container data volume manager for your Dockerized application.</li>
+<li><a href="https://github.com/gluster/glusterd2" rel="nofollow">glusterd2</a> - GlusterD-2.0 is the distributed management framework to be used for GlusterFS-4.0.</li>
+<li><a href="https://github.com/gluster/glusterfs" rel="nofollow">glusterfs</a> - Gluster is a software defined distributed storage that can scale to several petabytes. It provides interfaces for object, block and file storage.</li>
+<li><a href="https://github.com/goharbor/harbor" rel="nofollow">harbor</a> - An open source trusted cloud native registry project that stores, signs, and scans content.</li>
+<li><a href="https://github.com/heketi/heketi" rel="nofollow">heketi</a> - RESTful based volume management framework for GlusterFS.</li>
+<li><a href="https://github.com/hwameistor/hwameistor" rel="nofollow">hwameistor</a> - Hwameistor is an HA local storage system for cloud-native stateful workloads.</li>
+<li><a href="https://github.com/infinit/infinit" rel="nofollow">infinit</a> - The Infinit policy-based software-defined storage platform.</li>
+<li><a href="https://github.com/juicedata/juicefs" rel="nofollow">juicefs</a> - A distributed POSIX file system built on top of Redis and S3.</li>
+<li><a href="https://github.com/k8ssandra/k8ssandra" rel="nofollow">k8ssandra</a> - K8ssandra is a collection of Helm charts for running Apache Cassandra on Kubernetes in production.</li>
+<li><a href="https://github.com/configurator/kubefs" rel="nofollow">kubefs</a> - Mount kubernetes metadata storage as a filesystem.</li>
+<li><a href="https://leo-project.net/leofs/" rel="nofollow">leofs</a> - The LeoFS Storage System.</li>
+<li><a href="https://github.com/longhorn/longhorn" rel="nofollow">longhorn</a> - We put storage on cows and move them around from rancher.</li>
+<li><a href="https://github.com/minio/minio" rel="nofollow">minio</a> - Minio is an open source object storage server compatible with Amazon S3 APIs.</li>
+<li><a href="https://github.com/openebs/openebs" rel="nofollow">openebs</a> - OpenEBS is containerized block storage written in Go for cloud native and other environments w/ per container (or pod) QoS SLAs, tiering and replica policies across AZs and environments, and predictable and scalable performance.</li>
+<li><a href="https://github.com/oras-project/oras" rel="nofollow">oras</a> - OCI registry client, managing content like artifacts, images, packages.</li>
+<li><a href="https://github.com/kyma-project/rafter" rel="nofollow">rafter</a> - Kubernetes-native S3-like files/assets store based on CRDs and powered by MinIO.</li>
+<li><a href="https://github.com/rook/rook" rel="nofollow">rook</a> - File, Block, and Object Storage Services for your Cloud-Native Environment.</li>
+<li><a href="https://storageos.com/" rel="nofollow">storageos</a> - Enterprise persistent storage for containers and the cloud.</li>
+<li><a href="https://github.com/coreos/torus" rel="nofollow">torus</a> - Torus Distributed Storage.</li>
+<li><a href="https://github.com/vitessio/vitess" rel="nofollow">vitess</a> - Vitess is a database clustering system for horizontal scaling of MySQL.</li>
+<li><a href="https://github.com/scality/Zenko" rel="nofollow">zenko</a> - Because everyone should be in control of their data.</li>
+<li><a href="https://github.com/project-zot/zot" rel="nofollow">zot</a> - A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification).</li>
 </ul>
 <h2><a name="streaming-messaging" class="anchor" href="#streaming-messaging" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Streaming &amp; Messaging</h2>
@@ -628,6 +595,7 @@ Load Balancing &amp; Ingress</h2>
 <li><a href="https://github.com/projectcontour/contour" rel="nofollow">contour</a> - Contour is a Kubernetes ingress controller for Lyft&#39;s Envoy proxy.</li>
 <li><a href="https://github.com/microsoft/dev-proxy" rel="nofollow">dev-proxy</a> - Dev Proxy is a command line tool that simulates real world behaviors of HTTP APIs, including Microsoft Graph, locally.</li>
 <li><a href="https://github.com/envoyproxy/envoy" rel="nofollow">envoy</a> - C++ front/service proxy.</li>
+<li><a href="https://github.com/Nitro/envoy-docker-shim" rel="nofollow">envoy-docker-shim</a> - Run Envoy in place of docker-proxy.</li>
 <li><a href="https://github.com/tetratelabs/func-e" rel="nofollow">func-e</a> - func-e (pronounced funky) makes running Envoy easy.</li>
 <li><a href="https://github.com/projectcontour/gimbal" rel="nofollow">gimbal</a> - Heptio Gimbal is an ingress load balancing platform capable of routing traffic to multiple Kubernetes and OpenStack clusters. Built by Heptio in partnership with Actapio.</li>
 <li><a href="https://github.com/yyyar/gobetween" rel="nofollow">gobetween</a> - Modern &amp; minimalistic load balancer for the Сloud era.</li>
@@ -673,7 +641,6 @@ Runtimes &amp; Platforms</h2>
 <li><a href="https://github.com/deislabs/containerd-wasm-shims" rel="nofollow">containerd-wasm-shims</a> - Containerd shims for running WebAssembly workloads in Kubernetes.</li>
 <li><a href="https://github.com/cri-o/cri-o" rel="nofollow">cri-o</a> - Open Container Initiative-based implementation of Kubernetes Container Runtime Interface.</li>
 <li><a href="https://github.com/containers/crun" rel="nofollow">crun</a> - A fast and lightweight fully featured OCI runtime and C library for running containers.</li>
-<li><a href="https://github.com/us/den" rel="nofollow">den</a> - Self-hosted sandbox runtime for AI agents with isolated Docker containers, cgroup v2 memory management, and dynamic pressure monitoring.</li>
 <li><a href="https://github.com/firecracker-microvm/firecracker-containerd" rel="nofollow">firecracker-containerd</a> - firecracker-containerd enables containerd to manage containers as Firecracker microVMs.</li>
 <li><a href="https://github.com/kubernetes/frakti" rel="nofollow">frakti</a> - The hypervisor-based container runtime for Kubernetes.</li>
 <li><a href="https://github.com/google/gvisor" rel="nofollow">gvisor</a> - Sandboxed Container Runtime.</li>
@@ -685,7 +652,6 @@ Runtimes &amp; Platforms</h2>
 <li><a href="https://github.com/klts-io/kubernetes-lts" rel="nofollow">kubernetes-lts</a> - Kubernetes LTS(long term support).</li>
 <li><a href="https://github.com/AkihiroSuda/lima" rel="nofollow">lima</a> - Linux virtual machines, on macOS (aka &#34;Linux-on-Mac&#34;, &#34;macOS subsystem for Linux&#34;, &#34;containerd for Mac&#34;, unofficially).</li>
 <li><a href="https://github.com/moby/moby" rel="nofollow">moby</a> - Moby Project - a collaborative project for the container ecosystem to assemble container-based systems.</li>
-<li><a href="https://github.com/us/mocker" rel="nofollow">mocker</a> - Docker-compatible container CLI for macOS, built on Apple&#39;s Containerization framework.</li>
 <li><a href="https://github.com/containers/podman" rel="nofollow">podman</a> - A tool for managing OCI containers and pods.</li>
 <li><a href="https://github.com/alibaba/pouch" rel="nofollow">pouch</a> - Pouch is an open-source project created to promote the container technology movement.</li>
 <li><a href="https://github.com/oracle/railcar" rel="nofollow">railcar</a> - RailCar: Rust implementation of the Open Containers Initiative oci-runtime.</li>
@@ -770,7 +736,6 @@ Serverless Platforms</h2>
 Kubernetes Operators</h2>
 
 <ul>
-<li><a href="https://github.com/agenttier/agenttier" rel="nofollow">agenttier</a> - Kubernetes-native operator that manages isolated, persistent sandboxes for human developers and AI agents through Sandbox CRDs, with built-in governance, warm-pod pool, and a streaming agent-mode REST API.</li>
 <li><a href="https://github.com/banzaicloud/bank-vaults" rel="nofollow">banzaicloud/bank-vaults</a> - A Vault swiss-army knife: a K8s operator, Go client with automatic token renewal, automatic configuration, multiple unseal options and more. A CLI tool to init, unseal and configure Vault (auth methods, secret engines). Direct secret injection into Pods.</li>
 <li><a href="https://github.com/KohlsTechnology/eunomia" rel="nofollow">eunomia</a> - A GitOps Operator for Kubernetes.</li>
 <li><a href="https://github.com/FabEdge/fabedge" rel="nofollow">fabedge</a> - Secure Edge Networking Based On Kubernetes And KubeEdge.</li>
@@ -822,11 +787,11 @@ Observability &amp; Monitoring</h2>
 <li><a href="https://github.com/deviantony/docker-elk" rel="nofollow">docker-elk</a> - The ELK stack powered by Docker and Compose.</li>
 <li><a href="https://github.com/Netflix/bpftop" rel="nofollow">ebpftop</a> - bpftop provides a dynamic real-time view of running eBPF programs. It displays the average runtime, events per second, and estimated total CPU % for each program.</li>
 <li><a href="https://github.com/ElasticHQ/elasticsearch-HQ" rel="nofollow">elasticsearch-hq</a> - Monitoring and Management Web Application for ElasticSearch instances and clusters.</li>
+<li><a href="https://github.com/Nitro/envoy-ui" rel="nofollow">envoy-ui</a> - Dead simple server-side UI for Envoy proxy (like HAproxy stats).</li>
 <li><a href="https://github.com/bloomberg/goldpinger" rel="nofollow">goldpinger</a> - Debugging tool for Kubernetes which tests and displays connectivity between nodes in the cluster.</li>
 <li><a href="https://github.com/grafana/grafana" rel="nofollow">grafana</a> - The tool for beautiful monitoring and metric analytics &amp; dashboards for Graphite, InfluxDB &amp; Prometheus &amp; More.</li>
 <li><a href="https://github.com/hawkular/hawkular-metrics" rel="nofollow">hawkular-metrics</a> - Time Series Metrics Engine based on Cassandra.</li>
 <li><a href="https://github.com/highlight/highlight" rel="nofollow">highlight</a> - The open source, full-stack monitoring platform. Error monitoring, session replay, logging and more.</li>
-<li><a href="https://github.com/ingero-io/ingero" rel="nofollow">ingero</a> - eBPF-based GPU causal observability agent. Traces CUDA APIs and host kernel events to explain GPU latency in cloud-native environments. Helm chart and DaemonSet included.</li>
 <li><a href="https://github.com/inspektor-gadget/inspektor-gadget" rel="nofollow">inspektor-gadget</a> - The eBPF tool and systems inspection framework for Kubernetes, containers and Linux hosts.</li>
 <li><a href="https://github.com/jukylin/istio-ui" rel="nofollow">istio-ui</a> - Istio config management backend.</li>
 <li><a href="https://github.com/kubewharf/kelemetry" rel="nofollow">kelemetry</a> - Global control plane tracing for Kubernetes.</li>
@@ -907,11 +872,9 @@ Security &amp; Compliance</h2>
 <li><a href="https://gitlab.com/apparmor/apparmor/-/wikis/home" rel="nofollow">apparmor</a> - AppArmor is an effective and easy-to-use Linux application security system.</li>
 <li><a href="https://github.com/kubernetes-sigs/aws-iam-authenticator" rel="nofollow">authenticator</a> - A tool for using AWS IAM credentials to authenticate to a Kubernetes cluster.</li>
 <li><a href="https://github.com/socketkit/awacs" rel="nofollow">awacs</a> - Next-gen behavior analysis server (think Mixpanel, Google Analytics) with built-in encryption.</li>
-<li><a href="https://github.com/stacklok/brood-box" rel="nofollow">brood-box</a> - CLI tool for running coding agents inside hardware-isolated microVMs with workspace snapshot isolation and egress control.</li>
 <li><a href="https://github.com/cedar-policy/cedar" rel="nofollow">cedar</a> - Core implementation of the Cedar language.</li>
 <li><a href="https://github.com/jetstack/cert-manager" rel="nofollow">cert-manager</a> - Automatically provision and manage TLS certificates in Kubernetes.</li>
 <li><a href="https://github.com/bridgecrewio/checkov/" rel="nofollow">checkov</a> - A static analysis tool for infrastructure as code - to prevent misconfigs at build time.</li>
-<li><a href="https://github.com/gebalamariusz/cloud-audit" rel="nofollow">cloud-audit</a> - Fast, opinionated AWS security scanner with 47 curated checks. Each finding includes copy-paste remediation in AWS CLI and Terraform. Features attack chain detection and a diff command for CI/CD pipeline gating.</li>
 <li><a href="https://github.com/quay/clair" rel="nofollow">clair</a> - Vulnerability Static Analysis for Containers.</li>
 <li><a href="https://github.com/corazawaf/coraza" rel="nofollow">coraza</a> - OWASP Coraza WAF is a golang modsecurity compatible web application firewall library.</li>
 <li><a href="https://github.com/sigstore/cosign" rel="nofollow">cosign</a> - Container signing, verification, and provenance powered by Sigstore.</li>
@@ -925,7 +888,6 @@ Security &amp; Compliance</h2>
 <li><a href="https://github.com/firezone/firezone" rel="nofollow">firezone</a> - VPN server and Linux firewall built on WireGuard®. Supports SSO, MFA, and user-scoped access rules.</li>
 <li><a href="https://github.com/HewlettPackard/galadriel" rel="nofollow">galadriel</a> - SPIFFE Federation the easy way.</li>
 <li><a href="https://github.com/Caiyeon/goldfish" rel="nofollow">goldfish</a> - A HashiCorp Vault UI panel written with VueJS and Vault native Go API.</li>
-<li><a href="https://github.com/stacklok/go-microvm" rel="nofollow">go-microvm</a> - Go framework for running OCI images as microVMs via libkrun with embedded runtime, rootfs management, and guest networking.</li>
 <li><a href="https://github.com/Grafeas/Grafeas" rel="nofollow">grafeas</a> - Cloud artifact metadata CRUD API and resource specifications.</li>
 <li><a href="https://github.com/anchore/grype" rel="nofollow">grype</a> - A vulnerability scanner for container images and filesystems.</li>
 <li><a href="https://github.com/appscode/guard" rel="nofollow">guard</a> - Kubernetes Authentication WebHook Server.</li>
@@ -951,7 +913,6 @@ Security &amp; Compliance</h2>
 <li><a href="https://github.com/pomerium/pomerium/" rel="nofollow">pomerium</a> - Pomerium is a zero-trust context and identity aware access gateway inspired by BeyondCorp.</li>
 <li><a href="https://github.com/team-soteria/rback" rel="nofollow">rback</a> - RBAC in Kubernetes visualizer.</li>
 <li><a href="https://github.com/rond-authz/rond" rel="nofollow">rond</a> - A lightweight container for distributed security policy evaluation.</li>
-<li><a href="https://github.com/dormstern/segspec" rel="nofollow">segspec</a> - Extracts network dependencies from application config files and generates Kubernetes NetworkPolicies with evidence tracing.</li>
 <li><a href="https://github.com/spiffe/spiffe" rel="nofollow">spiffe</a> - The SPIFFE Project.</li>
 <li><a href="https://github.com/supertokens/supertokens-core" rel="nofollow">supertokens-core</a> - Open source alternative to Auth0 / Firebase Auth / AWS Cognito.</li>
 <li><a href="https://github.com/anchore/syft" rel="nofollow">syft</a> - CLI tool and library for generating a Software Bill of Materials from container images and filesystems.</li>
@@ -996,7 +957,6 @@ Dashboards &amp; Portals</h2>
 <li><a href="https://github.com/cloudfoundry" rel="nofollow">cloudfoundry</a> - Cloud Foundry is an open source, multi cloud application platform as a service (PaaS) governed by the Cloud Foundry Foundation.</li>
 <li><a href="https://github.com/conjure-up/conjure-up" rel="nofollow">conjure-up</a> - Deploying complex solutions, magically.</li>
 <li><a href="https://github.com/kubernetes/dashboard" rel="nofollow">dashboard</a> - General-purpose web UI for Kubernetes clusters.</li>
-<li><a href="https://github.com/AndrewVos/k100s" rel="nofollow">k100s</a> - Free, open-source desktop Kubernetes app for browsing pods, streaming logs, and opening pod shells.</li>
 <li><a href="https://github.com/KusionStack/karpor" rel="nofollow">karpor</a> - Intelligence for Kubernetes. World&#39;s most promising Kubernetes Visualization Tool for Developer and Platform Engineering teams.</li>
 <li><a href="https://github.com/kdash-rs/kdash" rel="nofollow">kdash</a> - A simple and fast dashboard for Kubernetes.</li>
 <li><a href="https://github.com/Mirantis/kqueen" rel="nofollow">kqeen</a> - Kubernetes queen - cluster manager.</li>
@@ -1004,14 +964,12 @@ Dashboards &amp; Portals</h2>
 <li><a href="https://github.com/kubermatic/kubermatic" rel="nofollow">kubermatic</a> - The Central Kubernetes Management Platform For Any Infrastructure.</li>
 <li><a href="https://github.com/smpio/kubernator" rel="nofollow">kubernator</a> - Alternative Kubernetes UI.</li>
 <li><a href="https://github.com/kubesphere/kubesphere" rel="nofollow">kubesphere</a> - Enterprise Container Managent Platform.</li>
-<li><a href="https://github.com/kubestellar/console" rel="nofollow">kubestellar</a> - KubeStellar Console is an AI-powered multi-cluster Kubernetes dashboard with natural language operations, MCP support, and GitOps deployment management.</li>
 <li><a href="https://github.com/kubevious/kubevious" rel="nofollow">kubevious</a> - Kubevious - application centric Kubernetes UI and continuous assurance provider.</li>
 <li><a href="https://github.com/viveksinghggits/kuui" rel="nofollow">kuui</a> - UI that can be used to edit configmaps/secrets of your kubernetes cluster.</li>
 <li><a href="https://github.com/oneinfra/oneinfra" rel="nofollow">oneinfra</a> - Kubernetes as a Service.</li>
 <li><a href="https://github.com/weibocom/opendcp" rel="nofollow">opendcp</a> - Docker platform developed by weibo.</li>
 <li><a href="https://github.com/openshift/origin" rel="nofollow">openshift</a> - Enterprise Kubernetes for Developers.</li>
 <li><a href="https://github.com/portainer/portainer" rel="nofollow">portainer</a> - Simple management UI for Docker.</li>
-<li><a href="https://github.com/skyhook-io/radar" rel="nofollow">radar</a> - Modern Kubernetes visibility tool with multi-cluster topology, image filesystem viewer, Helm and GitOps management, and built-in MCP server.</li>
 <li><a href="https://github.com/goodrain/rainbond" rel="nofollow">rainbond</a> - Serverless PaaS , A new generation of easy-to-use cloud management platforms based on kubernetes.</li>
 <li><a href="https://github.com/rancher/rancher" rel="nofollow">rancher</a> - Complete container management platform.</li>
 <li><a href="https://github.com/similarweb/statusbay" rel="nofollow">statusbay</a> - Kubernetes deployment visibility like a pro.</li>
@@ -1023,6 +981,7 @@ Tutorials &amp; Learning</h2>
 <ul>
 <li><a href="https://github.com/aws/aws-eks-best-practices/" rel="nofollow">aws-eks-best-practices</a> - A best practices guide for day 2 operations, including operational excellence, security, reliability, performance efficiency, and cost optimization.</li>
 <li><a href="https://github.com/aws-samples/aws-workshop-for-kubernetes" rel="nofollow">aws-workshop-for-kubernetes</a> - AWS Workshop for Kubernetes.</li>
+<li><a href="https://github.com/rootsongjc/cloud-native-library" rel="nofollow">cloud-native-library</a> - 云原生资料库 Cloud Native Library.</li>
 <li><a href="https://github.com/kamranahmedse/developer-roadmap" rel="nofollow">developer-roadmap</a> - Interactive roadmaps, guides and other educational content to help developers grow in their careers.</li>
 <li><a href="https://github.com/datawire/envoy-steps" rel="nofollow">envoy-steps</a> - Envoy Step by Step.</li>
 <li><a href="https://github.com/rootsongjc/envoy-tutorial" rel="nofollow">envoy-tutorial</a> - Envoy mesh in kubernetes tutorial.</li>

--- a/tmpl/index.html
+++ b/tmpl/index.html
@@ -121,6 +121,7 @@ API Gateways &amp; Proxies</h2>
 <li><a href="https://github.com/nginxinc/nginx-gateway-fabric" rel="nofollow">nginx-gateway-fabric</a> - NGINX Gateway Fabric provides an implementation for the Gateway API using NGINX as the data plane.</li>
 <li><a href="https://github.com/ThreeMammals/Ocelot" rel="nofollow">ocelot</a> - .NET core API Gateway.</li>
 <li><a href="https://github.com/orlabs/orange" rel="nofollow">orange</a> - OpenResty/Nginx Gateway for API Monitoring and Management.</li>
+<li><a href="https://github.com/soapbucket/sbproxy" rel="nofollow">sbproxy</a> - Single-binary AI gateway and reverse proxy with 103+ LLM providers, cost-based routing, rate limiting, and declarative YAML configuration.</li>
 <li><a href="https://github.com/TykTechnologies/tyk" rel="nofollow">tyk</a> - Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols.</li>
 </ul>
 <h2><a name="continuous-delivery-gitops" class="anchor" href="#continuous-delivery-gitops" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
@@ -212,6 +213,7 @@ Continuous Delivery &amp; GitOps</h2>
 <li><a href="https://github.com/banzaicloud/pipeline" rel="nofollow">pipeline</a> - REST API to provision or reuse managed Kubernetes clusters in the cloud and deploy cloud native apps.</li>
 <li><a href="https://github.com/tektoncd/pipeline" rel="nofollow">pipeline</a> - A cloud-native Pipeline resource.</li>
 <li><a href="https://github.com/pulumi/pulumi" rel="nofollow">pulumi</a> - A multi-language, multi-cloud development platform -- your code, your cloud, your team.</li>
+<li><a href="https://github.com/Qovery/qovery-skills" rel="nofollow">qovery</a> - Enterprise Kubernetes management platform for deploying applications, databases, Helm charts, and Terraform modules on AWS, GCP, Azure, and Scaleway. Includes Terraform provider, CLI, API, and AI Agent Skill.</li>
 <li><a href="https://github.com/splunk/qbec" rel="nofollow">qbec</a> - Configure kubernetes objects on multiple clusters using jsonnet.</li>
 <li><a href="https://github.com/radius-project/radius" rel="nofollow">radius</a> - Radius is a cloud-native, portable application platform that makes app development easier for teams building cloud-native apps.</li>
 <li><a href="https://github.com/screwdriver-cd/screwdriver" rel="nofollow">screwdriver</a> - An open source build platform designed for continuous delivery.</li>
@@ -269,6 +271,7 @@ Configuration &amp; Policy Automation</h2>
 <li><a href="https://github.com/open-feature/spec" rel="nofollow">openfeature</a> - Vendor-neutral feature flag standard and SDKs for cloud native apps.</li>
 <li><a href="https://github.com/FairwindsOps/pluto" rel="nofollow">pluto</a> - A cli tool to help discover deprecated apiVersions in Kubernetes.</li>
 <li><a href="https://github.com/stakater/Reloader" rel="nofollow">reloader</a> - A Kubernetes controller to watch changes in ConfigMap and Secrets and do rolling upgrades on Pods with their associated Deployment, StatefulSet, DaemonSet and DeploymentConfig.</li>
+<li><a href="https://github.com/Unleash/unleash" rel="nofollow">unleash</a> - Open-source feature management platform to decouple deploy from release and enable continuous delivery safely.</li>
 </ul>
 <h2><a name="cluster-provisioning-lifecycle" class="anchor" href="#cluster-provisioning-lifecycle" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Cluster Provisioning &amp; Lifecycle</h2>
@@ -365,6 +368,7 @@ Diagnostics &amp; Troubleshooting</h2>
 <li><a href="https://github.com/mr-karan/kubekutr" rel="nofollow">kubeutr</a> - Cookie cutter templating tool for scaffolding K8s manifests.</li>
 <li><a href="https://github.com/memfreeme/memfree" rel="nofollow">memfree</a> - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs. Support One-Click Deployment.</li>
 <li><a href="https://github.com/dpeckett/pangolin" rel="nofollow">pangolin</a> - An enhanced Horizontal Pod Autoscaler for Kubernetes.</li>
+<li><a href="https://github.com/Releaserun/releaserun-cli" rel="nofollow">releaserun-cli</a> - CLI tool to check Kubernetes manifests for deprecated/removed APIs, scan dependencies for vulnerabilities, and track version lifecycle status.</li>
 <li><a href="https://github.com/robusta-dev/robusta" rel="nofollow">robusta</a> - Open source Kubernetes troubleshooting and automation platform.</li>
 <li><a href="https://github.com/solo-io/squash" rel="nofollow">squash</a> - The debugger for microservices.</li>
 <li><a href="https://github.com/wercker/stern" rel="nofollow">stern</a> - Multi pod and container log tailing for Kubernetes.</li>
@@ -392,6 +396,7 @@ Data Protection &amp; Backup</h2>
 Cost &amp; Governance</h2>
 
 <ul>
+<li><a href="https://github.com/tanrikuluozlem/burn" rel="nofollow">burn</a> - CLI tool for Kubernetes cost analysis with per-namespace breakdown, real cloud pricing, and AI-powered recommendations.</li>
 <li><a href="https://github.com/kubecost/cost-model" rel="nofollow">cost-model</a> - Cross-cloud cost allocation models for workloads running on Kubernetes.</li>
 <li><a href="https://github.com/atlassian/escalator" rel="nofollow">escalator</a> - Escalator is a batch or job optimized horizontal autoscaler for Kubernetes.</li>
 <li><a href="https://github.com/aws/karpenter" rel="nofollow">karpenter</a> - Kubernetes Node Autoscaling: built for flexibility, performance, and scalability.</li>
@@ -463,33 +468,61 @@ Databases</h2>
 Storage &amp; Data Management</h2>
 
 <ul>
-<li><a href="https://github.com/ceph/ceph" rel="nofollow">ceph</a> - Ceph is a distributed object, block, and file storage platform.</li>
-<li><a href="https://github.com/chubaofs/chubaofs" rel="nofollow">chubaofs</a> - A distributed storage system for cloud native applications.</li>
-<li><a href="https://github.com/rancher/convoy" rel="nofollow">convoy</a> - A Docker volume plugin, managing persistent container volumes.</li>
-<li><a href="https://github.com/opencurve/curve" rel="nofollow">curve</a> - Curve is a better-used cloud-native SDS storage system, featured with high performance, easy operation, cloud native. Curve is composed with CurveBS and CurveFS based on Raft.</li>
-<li><a href="https://github.com/happyfish100/fastdfs" rel="nofollow">fastdfs</a> - FastDFS is an open source high performance distributed file system (DFS). It&#39;s major functions include: file storing, file syncing and file accessing, and design for high capacity and load balance.</li>
-<li><a href="https://github.com/ClusterHQ/flocker" rel="nofollow">flocker</a> - Container data volume manager for your Dockerized application.</li>
-<li><a href="https://github.com/gluster/glusterd2" rel="nofollow">glusterd2</a> - GlusterD-2.0 is the distributed management framework to be used for GlusterFS-4.0.</li>
-<li><a href="https://github.com/gluster/glusterfs" rel="nofollow">glusterfs</a> - Gluster is a software defined distributed storage that can scale to several petabytes. It provides interfaces for object, block and file storage.</li>
-<li><a href="https://github.com/goharbor/harbor" rel="nofollow">harbor</a> - An open source trusted cloud native registry project that stores, signs, and scans content.</li>
-<li><a href="https://github.com/heketi/heketi" rel="nofollow">heketi</a> - RESTful based volume management framework for GlusterFS.</li>
-<li><a href="https://github.com/hwameistor/hwameistor" rel="nofollow">hwameistor</a> - Hwameistor is an HA local storage system for cloud-native stateful workloads.</li>
-<li><a href="https://github.com/infinit/infinit" rel="nofollow">infinit</a> - The Infinit policy-based software-defined storage platform.</li>
-<li><a href="https://github.com/juicedata/juicefs" rel="nofollow">juicefs</a> - A distributed POSIX file system built on top of Redis and S3.</li>
-<li><a href="https://github.com/k8ssandra/k8ssandra" rel="nofollow">k8ssandra</a> - K8ssandra is a collection of Helm charts for running Apache Cassandra on Kubernetes in production.</li>
-<li><a href="https://github.com/configurator/kubefs" rel="nofollow">kubefs</a> - Mount kubernetes metadata storage as a filesystem.</li>
-<li><a href="https://leo-project.net/leofs/" rel="nofollow">leofs</a> - The LeoFS Storage System.</li>
-<li><a href="https://github.com/longhorn/longhorn" rel="nofollow">longhorn</a> - We put storage on cows and move them around from rancher.</li>
-<li><a href="https://github.com/minio/minio" rel="nofollow">minio</a> - Minio is an open source object storage server compatible with Amazon S3 APIs.</li>
-<li><a href="https://github.com/openebs/openebs" rel="nofollow">openebs</a> - OpenEBS is containerized block storage written in Go for cloud native and other environments w/ per container (or pod) QoS SLAs, tiering and replica policies across AZs and environments, and predictable and scalable performance.</li>
-<li><a href="https://github.com/oras-project/oras" rel="nofollow">oras</a> - OCI registry client, managing content like artifacts, images, packages.</li>
-<li><a href="https://github.com/kyma-project/rafter" rel="nofollow">rafter</a> - Kubernetes-native S3-like files/assets store based on CRDs and powered by MinIO.</li>
-<li><a href="https://github.com/rook/rook" rel="nofollow">rook</a> - File, Block, and Object Storage Services for your Cloud-Native Environment.</li>
-<li><a href="https://storageos.com/" rel="nofollow">storageos</a> - Enterprise persistent storage for containers and the cloud.</li>
-<li><a href="https://github.com/coreos/torus" rel="nofollow">torus</a> - Torus Distributed Storage.</li>
-<li><a href="https://github.com/vitessio/vitess" rel="nofollow">vitess</a> - Vitess is a database clustering system for horizontal scaling of MySQL.</li>
-<li><a href="https://github.com/scality/Zenko" rel="nofollow">zenko</a> - Because everyone should be in control of their data.</li>
-<li><a href="https://github.com/project-zot/zot" rel="nofollow">zot</a> - A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification).</li>
+<li><p><a href="https://github.com/mixpeek/awesome-object-storage" rel="nofollow">awesome-object-storage</a> - Curated comparison of 21 S3-compatible object storage providers with pricing, gotchas, and tools.</p></li>
+
+<li><p><a href="https://github.com/ceph/ceph" rel="nofollow">ceph</a> - Ceph is a distributed object, block, and file storage platform.</p></li>
+
+<li><p><a href="https://github.com/chubaofs/chubaofs" rel="nofollow">chubaofs</a> - A distributed storage system for cloud native applications.</p></li>
+
+<li><p><a href="https://github.com/rancher/convoy" rel="nofollow">convoy</a> - A Docker volume plugin, managing persistent container volumes.</p></li>
+
+<li><p><a href="https://github.com/opencurve/curve" rel="nofollow">curve</a> - Curve is a better-used cloud-native SDS storage system, featured with high performance, easy operation, cloud native. Curve is composed with CurveBS and CurveFS based on Raft.</p></li>
+
+<li><p><a href="https://github.com/happyfish100/fastdfs" rel="nofollow">fastdfs</a> - FastDFS is an open source high performance distributed file system (DFS). It&#39;s major functions include: file storing, file syncing and file accessing, and design for high capacity and load balance.</p></li>
+
+<li><p><a href="https://github.com/ClusterHQ/flocker" rel="nofollow">flocker</a> - Container data volume manager for your Dockerized application.</p></li>
+
+<li><p><a href="https://github.com/gluster/glusterd2" rel="nofollow">glusterd2</a> - GlusterD-2.0 is the distributed management framework to be used for GlusterFS-4.0.</p></li>
+
+<li><p><a href="https://github.com/gluster/glusterfs" rel="nofollow">glusterfs</a> - Gluster is a software defined distributed storage that can scale to several petabytes. It provides interfaces for object, block and file storage.</p></li>
+
+<li><p><a href="https://github.com/goharbor/harbor" rel="nofollow">harbor</a> - An open source trusted cloud native registry project that stores, signs, and scans content.</p></li>
+
+<li><p><a href="https://github.com/heketi/heketi" rel="nofollow">heketi</a> - RESTful based volume management framework for GlusterFS.</p></li>
+
+<li><p><a href="https://github.com/hwameistor/hwameistor" rel="nofollow">hwameistor</a> - Hwameistor is an HA local storage system for cloud-native stateful workloads.</p></li>
+
+<li><p><a href="https://github.com/infinit/infinit" rel="nofollow">infinit</a> - The Infinit policy-based software-defined storage platform.</p></li>
+
+<li><p><a href="https://github.com/juicedata/juicefs" rel="nofollow">juicefs</a> - A distributed POSIX file system built on top of Redis and S3.</p></li>
+
+<li><p><a href="https://github.com/k8ssandra/k8ssandra" rel="nofollow">k8ssandra</a> - K8ssandra is a collection of Helm charts for running Apache Cassandra on Kubernetes in production.</p></li>
+
+<li><p><a href="https://github.com/configurator/kubefs" rel="nofollow">kubefs</a> - Mount kubernetes metadata storage as a filesystem.</p></li>
+
+<li><p><a href="https://leo-project.net/leofs/" rel="nofollow">leofs</a> - The LeoFS Storage System.</p></li>
+
+<li><p><a href="https://github.com/longhorn/longhorn" rel="nofollow">longhorn</a> - We put storage on cows and move them around from rancher.</p></li>
+
+<li><p><a href="https://github.com/minio/minio" rel="nofollow">minio</a> - Minio is an open source object storage server compatible with Amazon S3 APIs.</p></li>
+
+<li><p><a href="https://github.com/openebs/openebs" rel="nofollow">openebs</a> - OpenEBS is containerized block storage written in Go for cloud native and other environments w/ per container (or pod) QoS SLAs, tiering and replica policies across AZs and environments, and predictable and scalable performance.</p></li>
+
+<li><p><a href="https://github.com/oras-project/oras" rel="nofollow">oras</a> - OCI registry client, managing content like artifacts, images, packages.</p></li>
+
+<li><p><a href="https://github.com/kyma-project/rafter" rel="nofollow">rafter</a> - Kubernetes-native S3-like files/assets store based on CRDs and powered by MinIO.</p></li>
+
+<li><p><a href="https://github.com/rook/rook" rel="nofollow">rook</a> - File, Block, and Object Storage Services for your Cloud-Native Environment.</p></li>
+
+<li><p><a href="https://storageos.com/" rel="nofollow">storageos</a> - Enterprise persistent storage for containers and the cloud.</p></li>
+
+<li><p><a href="https://github.com/coreos/torus" rel="nofollow">torus</a> - Torus Distributed Storage.</p></li>
+
+<li><p><a href="https://github.com/vitessio/vitess" rel="nofollow">vitess</a> - Vitess is a database clustering system for horizontal scaling of MySQL.</p></li>
+
+<li><p><a href="https://github.com/scality/Zenko" rel="nofollow">zenko</a> - Because everyone should be in control of their data.</p></li>
+
+<li><p><a href="https://github.com/project-zot/zot" rel="nofollow">zot</a> - A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification).</p></li>
 </ul>
 <h2><a name="streaming-messaging" class="anchor" href="#streaming-messaging" rel="nofollow" aria-hidden="true"><span class="octicon octicon-link"></span></a>
 Streaming &amp; Messaging</h2>
@@ -595,7 +628,6 @@ Load Balancing &amp; Ingress</h2>
 <li><a href="https://github.com/projectcontour/contour" rel="nofollow">contour</a> - Contour is a Kubernetes ingress controller for Lyft&#39;s Envoy proxy.</li>
 <li><a href="https://github.com/microsoft/dev-proxy" rel="nofollow">dev-proxy</a> - Dev Proxy is a command line tool that simulates real world behaviors of HTTP APIs, including Microsoft Graph, locally.</li>
 <li><a href="https://github.com/envoyproxy/envoy" rel="nofollow">envoy</a> - C++ front/service proxy.</li>
-<li><a href="https://github.com/Nitro/envoy-docker-shim" rel="nofollow">envoy-docker-shim</a> - Run Envoy in place of docker-proxy.</li>
 <li><a href="https://github.com/tetratelabs/func-e" rel="nofollow">func-e</a> - func-e (pronounced funky) makes running Envoy easy.</li>
 <li><a href="https://github.com/projectcontour/gimbal" rel="nofollow">gimbal</a> - Heptio Gimbal is an ingress load balancing platform capable of routing traffic to multiple Kubernetes and OpenStack clusters. Built by Heptio in partnership with Actapio.</li>
 <li><a href="https://github.com/yyyar/gobetween" rel="nofollow">gobetween</a> - Modern &amp; minimalistic load balancer for the Сloud era.</li>
@@ -641,6 +673,7 @@ Runtimes &amp; Platforms</h2>
 <li><a href="https://github.com/deislabs/containerd-wasm-shims" rel="nofollow">containerd-wasm-shims</a> - Containerd shims for running WebAssembly workloads in Kubernetes.</li>
 <li><a href="https://github.com/cri-o/cri-o" rel="nofollow">cri-o</a> - Open Container Initiative-based implementation of Kubernetes Container Runtime Interface.</li>
 <li><a href="https://github.com/containers/crun" rel="nofollow">crun</a> - A fast and lightweight fully featured OCI runtime and C library for running containers.</li>
+<li><a href="https://github.com/us/den" rel="nofollow">den</a> - Self-hosted sandbox runtime for AI agents with isolated Docker containers, cgroup v2 memory management, and dynamic pressure monitoring.</li>
 <li><a href="https://github.com/firecracker-microvm/firecracker-containerd" rel="nofollow">firecracker-containerd</a> - firecracker-containerd enables containerd to manage containers as Firecracker microVMs.</li>
 <li><a href="https://github.com/kubernetes/frakti" rel="nofollow">frakti</a> - The hypervisor-based container runtime for Kubernetes.</li>
 <li><a href="https://github.com/google/gvisor" rel="nofollow">gvisor</a> - Sandboxed Container Runtime.</li>
@@ -652,6 +685,7 @@ Runtimes &amp; Platforms</h2>
 <li><a href="https://github.com/klts-io/kubernetes-lts" rel="nofollow">kubernetes-lts</a> - Kubernetes LTS(long term support).</li>
 <li><a href="https://github.com/AkihiroSuda/lima" rel="nofollow">lima</a> - Linux virtual machines, on macOS (aka &#34;Linux-on-Mac&#34;, &#34;macOS subsystem for Linux&#34;, &#34;containerd for Mac&#34;, unofficially).</li>
 <li><a href="https://github.com/moby/moby" rel="nofollow">moby</a> - Moby Project - a collaborative project for the container ecosystem to assemble container-based systems.</li>
+<li><a href="https://github.com/us/mocker" rel="nofollow">mocker</a> - Docker-compatible container CLI for macOS, built on Apple&#39;s Containerization framework.</li>
 <li><a href="https://github.com/containers/podman" rel="nofollow">podman</a> - A tool for managing OCI containers and pods.</li>
 <li><a href="https://github.com/alibaba/pouch" rel="nofollow">pouch</a> - Pouch is an open-source project created to promote the container technology movement.</li>
 <li><a href="https://github.com/oracle/railcar" rel="nofollow">railcar</a> - RailCar: Rust implementation of the Open Containers Initiative oci-runtime.</li>
@@ -736,6 +770,7 @@ Serverless Platforms</h2>
 Kubernetes Operators</h2>
 
 <ul>
+<li><a href="https://github.com/agenttier/agenttier" rel="nofollow">agenttier</a> - Kubernetes-native operator that manages isolated, persistent sandboxes for human developers and AI agents through Sandbox CRDs, with built-in governance, warm-pod pool, and a streaming agent-mode REST API.</li>
 <li><a href="https://github.com/banzaicloud/bank-vaults" rel="nofollow">banzaicloud/bank-vaults</a> - A Vault swiss-army knife: a K8s operator, Go client with automatic token renewal, automatic configuration, multiple unseal options and more. A CLI tool to init, unseal and configure Vault (auth methods, secret engines). Direct secret injection into Pods.</li>
 <li><a href="https://github.com/KohlsTechnology/eunomia" rel="nofollow">eunomia</a> - A GitOps Operator for Kubernetes.</li>
 <li><a href="https://github.com/FabEdge/fabedge" rel="nofollow">fabedge</a> - Secure Edge Networking Based On Kubernetes And KubeEdge.</li>
@@ -787,11 +822,11 @@ Observability &amp; Monitoring</h2>
 <li><a href="https://github.com/deviantony/docker-elk" rel="nofollow">docker-elk</a> - The ELK stack powered by Docker and Compose.</li>
 <li><a href="https://github.com/Netflix/bpftop" rel="nofollow">ebpftop</a> - bpftop provides a dynamic real-time view of running eBPF programs. It displays the average runtime, events per second, and estimated total CPU % for each program.</li>
 <li><a href="https://github.com/ElasticHQ/elasticsearch-HQ" rel="nofollow">elasticsearch-hq</a> - Monitoring and Management Web Application for ElasticSearch instances and clusters.</li>
-<li><a href="https://github.com/Nitro/envoy-ui" rel="nofollow">envoy-ui</a> - Dead simple server-side UI for Envoy proxy (like HAproxy stats).</li>
 <li><a href="https://github.com/bloomberg/goldpinger" rel="nofollow">goldpinger</a> - Debugging tool for Kubernetes which tests and displays connectivity between nodes in the cluster.</li>
 <li><a href="https://github.com/grafana/grafana" rel="nofollow">grafana</a> - The tool for beautiful monitoring and metric analytics &amp; dashboards for Graphite, InfluxDB &amp; Prometheus &amp; More.</li>
 <li><a href="https://github.com/hawkular/hawkular-metrics" rel="nofollow">hawkular-metrics</a> - Time Series Metrics Engine based on Cassandra.</li>
 <li><a href="https://github.com/highlight/highlight" rel="nofollow">highlight</a> - The open source, full-stack monitoring platform. Error monitoring, session replay, logging and more.</li>
+<li><a href="https://github.com/ingero-io/ingero" rel="nofollow">ingero</a> - eBPF-based GPU causal observability agent. Traces CUDA APIs and host kernel events to explain GPU latency in cloud-native environments. Helm chart and DaemonSet included.</li>
 <li><a href="https://github.com/inspektor-gadget/inspektor-gadget" rel="nofollow">inspektor-gadget</a> - The eBPF tool and systems inspection framework for Kubernetes, containers and Linux hosts.</li>
 <li><a href="https://github.com/jukylin/istio-ui" rel="nofollow">istio-ui</a> - Istio config management backend.</li>
 <li><a href="https://github.com/kubewharf/kelemetry" rel="nofollow">kelemetry</a> - Global control plane tracing for Kubernetes.</li>
@@ -872,9 +907,11 @@ Security &amp; Compliance</h2>
 <li><a href="https://gitlab.com/apparmor/apparmor/-/wikis/home" rel="nofollow">apparmor</a> - AppArmor is an effective and easy-to-use Linux application security system.</li>
 <li><a href="https://github.com/kubernetes-sigs/aws-iam-authenticator" rel="nofollow">authenticator</a> - A tool for using AWS IAM credentials to authenticate to a Kubernetes cluster.</li>
 <li><a href="https://github.com/socketkit/awacs" rel="nofollow">awacs</a> - Next-gen behavior analysis server (think Mixpanel, Google Analytics) with built-in encryption.</li>
+<li><a href="https://github.com/stacklok/brood-box" rel="nofollow">brood-box</a> - CLI tool for running coding agents inside hardware-isolated microVMs with workspace snapshot isolation and egress control.</li>
 <li><a href="https://github.com/cedar-policy/cedar" rel="nofollow">cedar</a> - Core implementation of the Cedar language.</li>
 <li><a href="https://github.com/jetstack/cert-manager" rel="nofollow">cert-manager</a> - Automatically provision and manage TLS certificates in Kubernetes.</li>
 <li><a href="https://github.com/bridgecrewio/checkov/" rel="nofollow">checkov</a> - A static analysis tool for infrastructure as code - to prevent misconfigs at build time.</li>
+<li><a href="https://github.com/gebalamariusz/cloud-audit" rel="nofollow">cloud-audit</a> - Fast, opinionated AWS security scanner with 47 curated checks. Each finding includes copy-paste remediation in AWS CLI and Terraform. Features attack chain detection and a diff command for CI/CD pipeline gating.</li>
 <li><a href="https://github.com/quay/clair" rel="nofollow">clair</a> - Vulnerability Static Analysis for Containers.</li>
 <li><a href="https://github.com/corazawaf/coraza" rel="nofollow">coraza</a> - OWASP Coraza WAF is a golang modsecurity compatible web application firewall library.</li>
 <li><a href="https://github.com/sigstore/cosign" rel="nofollow">cosign</a> - Container signing, verification, and provenance powered by Sigstore.</li>
@@ -888,6 +925,7 @@ Security &amp; Compliance</h2>
 <li><a href="https://github.com/firezone/firezone" rel="nofollow">firezone</a> - VPN server and Linux firewall built on WireGuard®. Supports SSO, MFA, and user-scoped access rules.</li>
 <li><a href="https://github.com/HewlettPackard/galadriel" rel="nofollow">galadriel</a> - SPIFFE Federation the easy way.</li>
 <li><a href="https://github.com/Caiyeon/goldfish" rel="nofollow">goldfish</a> - A HashiCorp Vault UI panel written with VueJS and Vault native Go API.</li>
+<li><a href="https://github.com/stacklok/go-microvm" rel="nofollow">go-microvm</a> - Go framework for running OCI images as microVMs via libkrun with embedded runtime, rootfs management, and guest networking.</li>
 <li><a href="https://github.com/Grafeas/Grafeas" rel="nofollow">grafeas</a> - Cloud artifact metadata CRUD API and resource specifications.</li>
 <li><a href="https://github.com/anchore/grype" rel="nofollow">grype</a> - A vulnerability scanner for container images and filesystems.</li>
 <li><a href="https://github.com/appscode/guard" rel="nofollow">guard</a> - Kubernetes Authentication WebHook Server.</li>
@@ -913,6 +951,7 @@ Security &amp; Compliance</h2>
 <li><a href="https://github.com/pomerium/pomerium/" rel="nofollow">pomerium</a> - Pomerium is a zero-trust context and identity aware access gateway inspired by BeyondCorp.</li>
 <li><a href="https://github.com/team-soteria/rback" rel="nofollow">rback</a> - RBAC in Kubernetes visualizer.</li>
 <li><a href="https://github.com/rond-authz/rond" rel="nofollow">rond</a> - A lightweight container for distributed security policy evaluation.</li>
+<li><a href="https://github.com/dormstern/segspec" rel="nofollow">segspec</a> - Extracts network dependencies from application config files and generates Kubernetes NetworkPolicies with evidence tracing.</li>
 <li><a href="https://github.com/spiffe/spiffe" rel="nofollow">spiffe</a> - The SPIFFE Project.</li>
 <li><a href="https://github.com/supertokens/supertokens-core" rel="nofollow">supertokens-core</a> - Open source alternative to Auth0 / Firebase Auth / AWS Cognito.</li>
 <li><a href="https://github.com/anchore/syft" rel="nofollow">syft</a> - CLI tool and library for generating a Software Bill of Materials from container images and filesystems.</li>
@@ -957,6 +996,7 @@ Dashboards &amp; Portals</h2>
 <li><a href="https://github.com/cloudfoundry" rel="nofollow">cloudfoundry</a> - Cloud Foundry is an open source, multi cloud application platform as a service (PaaS) governed by the Cloud Foundry Foundation.</li>
 <li><a href="https://github.com/conjure-up/conjure-up" rel="nofollow">conjure-up</a> - Deploying complex solutions, magically.</li>
 <li><a href="https://github.com/kubernetes/dashboard" rel="nofollow">dashboard</a> - General-purpose web UI for Kubernetes clusters.</li>
+<li><a href="https://github.com/AndrewVos/k100s" rel="nofollow">k100s</a> - Free, open-source desktop Kubernetes app for browsing pods, streaming logs, and opening pod shells.</li>
 <li><a href="https://github.com/KusionStack/karpor" rel="nofollow">karpor</a> - Intelligence for Kubernetes. World&#39;s most promising Kubernetes Visualization Tool for Developer and Platform Engineering teams.</li>
 <li><a href="https://github.com/kdash-rs/kdash" rel="nofollow">kdash</a> - A simple and fast dashboard for Kubernetes.</li>
 <li><a href="https://github.com/Mirantis/kqueen" rel="nofollow">kqeen</a> - Kubernetes queen - cluster manager.</li>
@@ -964,12 +1004,14 @@ Dashboards &amp; Portals</h2>
 <li><a href="https://github.com/kubermatic/kubermatic" rel="nofollow">kubermatic</a> - The Central Kubernetes Management Platform For Any Infrastructure.</li>
 <li><a href="https://github.com/smpio/kubernator" rel="nofollow">kubernator</a> - Alternative Kubernetes UI.</li>
 <li><a href="https://github.com/kubesphere/kubesphere" rel="nofollow">kubesphere</a> - Enterprise Container Managent Platform.</li>
+<li><a href="https://github.com/kubestellar/console" rel="nofollow">kubestellar</a> - KubeStellar Console is an AI-powered multi-cluster Kubernetes dashboard with natural language operations, MCP support, and GitOps deployment management.</li>
 <li><a href="https://github.com/kubevious/kubevious" rel="nofollow">kubevious</a> - Kubevious - application centric Kubernetes UI and continuous assurance provider.</li>
 <li><a href="https://github.com/viveksinghggits/kuui" rel="nofollow">kuui</a> - UI that can be used to edit configmaps/secrets of your kubernetes cluster.</li>
 <li><a href="https://github.com/oneinfra/oneinfra" rel="nofollow">oneinfra</a> - Kubernetes as a Service.</li>
 <li><a href="https://github.com/weibocom/opendcp" rel="nofollow">opendcp</a> - Docker platform developed by weibo.</li>
 <li><a href="https://github.com/openshift/origin" rel="nofollow">openshift</a> - Enterprise Kubernetes for Developers.</li>
 <li><a href="https://github.com/portainer/portainer" rel="nofollow">portainer</a> - Simple management UI for Docker.</li>
+<li><a href="https://github.com/skyhook-io/radar" rel="nofollow">radar</a> - Modern Kubernetes visibility tool with multi-cluster topology, image filesystem viewer, Helm and GitOps management, and built-in MCP server.</li>
 <li><a href="https://github.com/goodrain/rainbond" rel="nofollow">rainbond</a> - Serverless PaaS , A new generation of easy-to-use cloud management platforms based on kubernetes.</li>
 <li><a href="https://github.com/rancher/rancher" rel="nofollow">rancher</a> - Complete container management platform.</li>
 <li><a href="https://github.com/similarweb/statusbay" rel="nofollow">statusbay</a> - Kubernetes deployment visibility like a pro.</li>
@@ -981,7 +1023,6 @@ Tutorials &amp; Learning</h2>
 <ul>
 <li><a href="https://github.com/aws/aws-eks-best-practices/" rel="nofollow">aws-eks-best-practices</a> - A best practices guide for day 2 operations, including operational excellence, security, reliability, performance efficiency, and cost optimization.</li>
 <li><a href="https://github.com/aws-samples/aws-workshop-for-kubernetes" rel="nofollow">aws-workshop-for-kubernetes</a> - AWS Workshop for Kubernetes.</li>
-<li><a href="https://github.com/rootsongjc/cloud-native-library" rel="nofollow">cloud-native-library</a> - 云原生资料库 Cloud Native Library.</li>
 <li><a href="https://github.com/kamranahmedse/developer-roadmap" rel="nofollow">developer-roadmap</a> - Interactive roadmaps, guides and other educational content to help developers grow in their careers.</li>
 <li><a href="https://github.com/datawire/envoy-steps" rel="nofollow">envoy-steps</a> - Envoy Step by Step.</li>
 <li><a href="https://github.com/rootsongjc/envoy-tutorial" rel="nofollow">envoy-tutorial</a> - Envoy mesh in kubernetes tutorial.</li>


### PR DESCRIPTION
Adds k100s to Dashboards & Portals.

k100s is a free, open-source desktop Kubernetes app for users who want a k9s-like workflow in a GUI. It uses local kubectl/kubeconfig for context and namespace switching, pod lists, streamed logs, describes, and pod shells.

Checks:
- git diff --check
- go run ./repo.go
- go test ./... (fails on existing ordering issues in unrelated Continuous Delivery & GitOps and Security & Compliance sections; the k100s ordering issue is fixed)