### PR TITLE
Update watchtower link to maintained fork (upstream archived)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [packer](https://github.com/hashicorp/packer) - Packer is a tool for creating identical machine images for multiple platforms from a single source configuration.
 - [skopeo](https://github.com/containers/skopeo) - Work with remote images registries - retrieving information, images, signing content.
 - [tini](https://github.com/krallin/tini) - A tiny but valid `init` for containers.
-- [watchtower](https://github.com/containrrr/watchtower) - Automatically update running Docker containers.
+- [watchtower](https://github.com/openserbia/watchtower) - Automatically update running Docker containers.
 
 ## Configuration & Policy Automation
 


### PR DESCRIPTION
Updates the `watchtower` entry to point at the actively maintained fork [`openserbia/watchtower`](https://github.com/openserbia/watchtower). `containrrr/watchtower` was archived (read-only) on 2025-12-17 and no longer works on current Docker Engine (28/29).

The entry name and position are unchanged (still `watchtower`), so alphabetical ordering is unaffected — link text remains the canonical project name per the contribution guidelines.

Per CONTRIBUTING I ran `go test ./...`: it reports **pre-existing** alphabetical-ordering failures in unrelated categories (Continuous Delivery & GitOps: `qbec`/`qovery`; Security & Compliance: `clair`/`cloud-audit`, `go-microvm`/`goldfish`) that are present on `main` before this change — this PR neither causes nor fixes them. I left `tmpl/index.html` out because `go run ./repo.go` pulls in unrelated content drift already present on `main`; happy to include a regeneration if you prefer.

Disclosure: I maintain the fork. Other maintained forks exist too (e.g. `nicholas-fedor/watchtower`).
