### PR TITLE
Add JSDoc type annotations to Lexer function

### DIFF
--- a/tmpl/assets/marked.js
+++ b/tmpl/assets/marked.js
@@ -97,6 +97,8 @@ block.tables = merge({}, block.gfm, {
 
 /**
  * Block Lexer
+ * @param {Object} options - Options for lexing.
+ * @returns {Lexer} Lexer instance.
  */
 
 function Lexer(options) {


### PR DESCRIPTION
## Problem
The public function `Lexer` in `marked.js` lacks JSDoc type annotations, which affects code readability and maintainability. This makes it harder for developers to understand the function's parameters and return types at a glance.

## Changes
- Added JSDoc comments to the `Lexer` function in `tmpl/assets/marked.js` to document its parameters and return type.
- Ensured the annotations are consistent with JavaScript standards and the existing code style.

## Verification
- The changes are purely documentation-related and do not alter the function's behavior or API.
- Code review can verify the accuracy of the type annotations.
- No functional tests are required as the external behavior remains unchanged.