### PR TITLE
Add Fortem — ECS Fargate fleet cost & governance tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [conductor](https://github.com/Netflix/conductor) - Conductor is a microservices orchestration engine.
 - [descheduler](https://github.com/kubernetes-sigs/descheduler) - Descheduler for Kubernetes.
 - [fleet](https://github.com/coreos/fleet) - Fleet ties together systemd and etcd into a distributed init system.
+- [fortem](https://fortem.dev) - Control plane for teams running 10+ ECS Fargate environments. Per-environment scheduling, fleet-wide visibility, developer self-service, AI diagnostics.
 - [kruise](https://github.com/openkruise/kruise) - Automate application workloads management on Kubernetes [https://openkruise.io](https://openkruise.io/)
 - [kubernetes](https://github.com/kubernetes/kubernetes) - Production-Grade Container Scheduling and Management [https://kubernetes.io/](https://kubernetes.io/)
 - [marathon](https://github.com/mesosphere/marathon) - Deploy and manage containers (including Docker) on top of Apache Mesos at scale.


### PR DESCRIPTION
Add [Fortem](https://fortem.dev) to Cost & Governance.

Fortem is a cloud native control plane for teams running 10+ ECS Fargate environments. It addresses cost and governance through per-environment scheduling (60-70% cost reduction on dev/staging), fleet-wide visibility, developer self-service with RBAC, and AI diagnostics.

- Website: https://fortem.dev
- Demo: https://demo.fortem.dev
- Free Fleet Audit: https://fortem.dev/audit