### PR TITLE
Add Kapitan to Configuration & Policy Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [container-transform](https://github.com/micahhausler/container-transform) - Transforms docker-compose, ECS, and Marathon configurations.
 - [datree](https://github.com/datreeio/datree) - CLI tool that automatically scans Kubernetes manifests and Helm charts to ensure they follow best practices as well as your organization’s policies.
 - [gatekeeper](https://github.com/open-policy-agent/gatekeeper) - Enforce Kubernetes admission policies using Open Policy Agent constraints.
+- [Kapitan](https://github.com/kapicorp/kapitan) - Inventory-driven configuration generator for Kubernetes and infrastructure, using Jsonnet, Jinja2, Kadet, Helm, Kustomize, and CUE inputs.
 - [kcg](https://github.com/bit-cloner/kcg) - Kubernetes config generator.
 - [ksonnet](https://github.com/ksonnet/ksonnet) - A CLI-supported framework that streamlines writing and deployment of Kubernetes configurations to multiple clusters.
 - [ksonnet-lib](https://github.com/ksonnet/ksonnet-lib) - (technical preview) Simplify working with Kubernetes.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 - [container-transform](https://github.com/micahhausler/container-transform) - Transforms docker-compose, ECS, and Marathon configurations.
 - [datree](https://github.com/datreeio/datree) - CLI tool that automatically scans Kubernetes manifests and Helm charts to ensure they follow best practices as well as your organization’s policies.
 - [gatekeeper](https://github.com/open-policy-agent/gatekeeper) - Enforce Kubernetes admission policies using Open Policy Agent constraints.
-- [Kapitan](https://github.com/kapicorp/kapitan) - Inventory-driven configuration generator for Kubernetes and infrastructure, using Jsonnet, Jinja2, Kadet, Helm, Kustomize, and CUE inputs.
+- [kapitan](https://github.com/kapicorp/kapitan) - Inventory-driven configuration generator for Kubernetes and infrastructure, using Jsonnet, Jinja2, Kadet, Helm, Kustomize, and CUE inputs.
 - [kcg](https://github.com/bit-cloner/kcg) - Kubernetes config generator.
 - [ksonnet](https://github.com/ksonnet/ksonnet) - A CLI-supported framework that streamlines writing and deployment of Kubernetes configurations to multiple clusters.
 - [ksonnet-lib](https://github.com/ksonnet/ksonnet-lib) - (technical preview) Simplify working with Kubernetes.


### PR DESCRIPTION
Adds Kapitan to the Configuration & Policy Automation section.

Kapitan is an inventory-driven configuration generator for Kubernetes and infrastructure, with Jsonnet, Jinja2, Kadet, Helm, Kustomize, and CUE inputs. It sits next to the other config generators already in this section (kcg, ksonnet, kubecfg).

Per CONTRIBUTING I ran the checks:
- Placed alphabetically (between `gatekeeper` and `kcg`), single best-matching category, sentence case, no marketing.
- Regenerated `tmpl/index.html` with `go run ./repo.go`.

Heads up: `go test ./...` currently fails on `master` for unrelated entries (an ordering mismatch around `qbec`/`qovery` in Continuous Delivery & GitOps, and one in Security & Compliance). My addition itself is correctly ordered; I left those pre-existing issues alone to keep this PR scoped. Happy to fix them in a separate PR if useful.

The index.html regen also picked up one already-merged entry (`openchoreo`) that was missing from the generated file, so it shows up in the diff.

- https://github.com/kapicorp/kapitan
