### PR TITLE
Add BunkerWeb to Load Balancing & Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 ## Load Balancing & Ingress
 
 - [apisix-ingress-controller](https://github.com/apache/apisix-ingress-controller) - Ingress controller for K8s.
+- [BunkerWeb](https://github.com/bunkerity/bunkerweb) - Open-source Web Application Firewall and reverse proxy with Kubernetes integration.
 - [caddy](https://github.com/caddyserver/caddy) - Fast, cross-platform HTTP/2 web server with automatic HTTPS.
 - [cloudflared](https://github.com/cloudflare/cloudflared) - Cloudflare Tunnel client (formerly Argo Tunnel).
 - [contour](https://github.com/projectcontour/contour) - Contour is a Kubernetes ingress controller for Lyft's Envoy proxy.

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 ## Load Balancing & Ingress
 
 - [apisix-ingress-controller](https://github.com/apache/apisix-ingress-controller) - Ingress controller for K8s.
-- [BunkerWeb](https://github.com/bunkerity/bunkerweb) - Open-source Web Application Firewall and reverse proxy with Kubernetes integration.
+- [bunkerweb](https://github.com/bunkerity/bunkerweb) - Open-source Web Application Firewall and reverse proxy with Kubernetes integration.
 - [caddy](https://github.com/caddyserver/caddy) - Fast, cross-platform HTTP/2 web server with automatic HTTPS.
 - [cloudflared](https://github.com/cloudflare/cloudflared) - Cloudflare Tunnel client (formerly Argo Tunnel).
 - [contour](https://github.com/projectcontour/contour) - Contour is a Kubernetes ingress controller for Lyft's Envoy proxy.

--- a/tmpl/index.html
+++ b/tmpl/index.html
@@ -598,6 +598,7 @@ Load Balancing &amp; Ingress</h2>
 
 <ul>
 <li><a href="https://github.com/apache/apisix-ingress-controller" rel="nofollow">apisix-ingress-controller</a> - Ingress controller for K8s.</li>
+<li><a href="https://github.com/bunkerity/bunkerweb" rel="nofollow">BunkerWeb</a> - Open-source Web Application Firewall and reverse proxy with Kubernetes integration.</li>
 <li><a href="https://github.com/caddyserver/caddy" rel="nofollow">caddy</a> - Fast, cross-platform HTTP/2 web server with automatic HTTPS.</li>
 <li><a href="https://github.com/cloudflare/cloudflared" rel="nofollow">cloudflared</a> - Cloudflare Tunnel client (formerly Argo Tunnel).</li>
 <li><a href="https://github.com/projectcontour/contour" rel="nofollow">contour</a> - Contour is a Kubernetes ingress controller for Lyft&#39;s Envoy proxy.</li>

--- a/tmpl/index.html
+++ b/tmpl/index.html
@@ -598,7 +598,6 @@ Load Balancing &amp; Ingress</h2>
 
 <ul>
 <li><a href="https://github.com/apache/apisix-ingress-controller" rel="nofollow">apisix-ingress-controller</a> - Ingress controller for K8s.</li>
-<li><a href="https://github.com/bunkerity/bunkerweb" rel="nofollow">BunkerWeb</a> - Open-source Web Application Firewall and reverse proxy with Kubernetes integration.</li>
 <li><a href="https://github.com/caddyserver/caddy" rel="nofollow">caddy</a> - Fast, cross-platform HTTP/2 web server with automatic HTTPS.</li>
 <li><a href="https://github.com/cloudflare/cloudflared" rel="nofollow">cloudflared</a> - Cloudflare Tunnel client (formerly Argo Tunnel).</li>
 <li><a href="https://github.com/projectcontour/contour" rel="nofollow">contour</a> - Contour is a Kubernetes ingress controller for Lyft&#39;s Envoy proxy.</li>


### PR DESCRIPTION
Adds BunkerWeb to Load Balancing & Ingress as an open-source Web Application Firewall and reverse proxy with Kubernetes integration. The generated index includes the matching entry.

Checks:

- `go test -count=1 ./...`
- `go run ./repo.go`
- `git diff --check`
