### PR TITLE
Add Attune to Cost & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Cloud Native is a behavior and design philosophy. At its essence, any behavior o
 
 ## Cost & Governance
 
+- [Attune](https://github.com/attune-io/attune) - Kubernetes operator for in-place pod resource right-sizing from Prometheus metrics.
 - [burn](https://github.com/tanrikuluozlem/burn) - CLI tool for Kubernetes cost analysis with per-namespace breakdown, real cloud pricing, and AI-powered recommendations.
 - [cost-model](https://github.com/kubecost/cost-model) - Cross-cloud cost allocation models for workloads running on Kubernetes.
 - [escalator](https://github.com/atlassian/escalator) - Escalator is a batch or job optimized horizontal autoscaler for Kubernetes.

--- a/tmpl/index.html
+++ b/tmpl/index.html
@@ -213,8 +213,8 @@ Continuous Delivery &amp; GitOps</h2>
 <li><a href="https://github.com/banzaicloud/pipeline" rel="nofollow">pipeline</a> - REST API to provision or reuse managed Kubernetes clusters in the cloud and deploy cloud native apps.</li>
 <li><a href="https://github.com/tektoncd/pipeline" rel="nofollow">pipeline</a> - A cloud-native Pipeline resource.</li>
 <li><a href="https://github.com/pulumi/pulumi" rel="nofollow">pulumi</a> - A multi-language, multi-cloud development platform -- your code, your cloud, your team.</li>
-<li><a href="https://github.com/Qovery/qovery-skills" rel="nofollow">qovery</a> - Enterprise Kubernetes management platform for deploying applications, databases, Helm charts, and Terraform modules on AWS, GCP, Azure, and Scaleway. Includes Terraform provider, CLI, API, and AI Agent Skill.</li>
 <li><a href="https://github.com/splunk/qbec" rel="nofollow">qbec</a> - Configure kubernetes objects on multiple clusters using jsonnet.</li>
+<li><a href="https://github.com/Qovery/qovery-skills" rel="nofollow">qovery</a> - Enterprise Kubernetes management platform for deploying applications, databases, Helm charts, and Terraform modules on AWS, GCP, Azure, and Scaleway. Includes Terraform provider, CLI, API, and AI Agent Skill.</li>
 <li><a href="https://github.com/radius-project/radius" rel="nofollow">radius</a> - Radius is a cloud-native, portable application platform that makes app development easier for teams building cloud-native apps.</li>
 <li><a href="https://github.com/screwdriver-cd/screwdriver" rel="nofollow">screwdriver</a> - An open source build platform designed for continuous delivery.</li>
 <li><a href="https://github.com/alibaba/sealer" rel="nofollow">sealer</a> - Seal your applications all dependencies and kubernetes into CloudImage! Build Deliver and Run user-defined clusters in one command.</li>
@@ -304,6 +304,7 @@ Cluster Provisioning &amp; Lifecycle</h2>
 <li><a href="https://github.com/ubuntu/microk8s" rel="nofollow">microk8s</a> - A kubernetes cluster in a snap.</li>
 <li><a href="https://github.com/kubernetes/minikube" rel="nofollow">minikube</a> - Run Kubernetes locally.</li>
 <li><a href="https://github.com/labring/sealos" rel="nofollow">sealos</a> - Sealos is a Kubernetes distribution offering comprehensive solutions for both public and private clouds.</li>
+<li><a href="https://github.com/mulgadc/spinifex" rel="nofollow">spinifex</a> - Open source AWS-compatible platform for bare-metal, on-prem, and edge deployments. Run EC2, S3, EBS, and VPC-compatible services on your own hardware — no managed cloud required.</li>
 <li><a href="https://github.com/talos-systems/talos" rel="nofollow">talos</a> - A modern OS for Kubernetes.</li>
 <li><a href="https://github.com/coreos/tectonic-installer" rel="nofollow">tectonic-installer</a> - Install a Kubernetes cluster the CoreOS Tectonic Way: HA, self-hosted, RBAC, etcd Operator, and more.</li>
 <li><a href="https://github.com/virtual-kubelet/tensile-kube" rel="nofollow">tensile-kube</a> - A Kubernetes Provider.</li>
@@ -398,6 +399,7 @@ Data Protection &amp; Backup</h2>
 Cost &amp; Governance</h2>
 
 <ul>
+<li><a href="https://github.com/attune-io/attune" rel="nofollow">Attune</a> - Kubernetes operator for in-place pod resource right-sizing from Prometheus metrics.</li>
 <li><a href="https://github.com/tanrikuluozlem/burn" rel="nofollow">burn</a> - CLI tool for Kubernetes cost analysis with per-namespace breakdown, real cloud pricing, and AI-powered recommendations.</li>
 <li><a href="https://github.com/kubecost/cost-model" rel="nofollow">cost-model</a> - Cross-cloud cost allocation models for workloads running on Kubernetes.</li>
 <li><a href="https://github.com/atlassian/escalator" rel="nofollow">escalator</a> - Escalator is a batch or job optimized horizontal autoscaler for Kubernetes.</li>
@@ -598,6 +600,7 @@ Load Balancing &amp; Ingress</h2>
 
 <ul>
 <li><a href="https://github.com/apache/apisix-ingress-controller" rel="nofollow">apisix-ingress-controller</a> - Ingress controller for K8s.</li>
+<li><a href="https://github.com/bunkerity/bunkerweb" rel="nofollow">bunkerweb</a> - Open-source Web Application Firewall and reverse proxy with Kubernetes integration.</li>
 <li><a href="https://github.com/caddyserver/caddy" rel="nofollow">caddy</a> - Fast, cross-platform HTTP/2 web server with automatic HTTPS.</li>
 <li><a href="https://github.com/cloudflare/cloudflared" rel="nofollow">cloudflared</a> - Cloudflare Tunnel client (formerly Argo Tunnel).</li>
 <li><a href="https://github.com/projectcontour/contour" rel="nofollow">contour</a> - Contour is a Kubernetes ingress controller for Lyft&#39;s Envoy proxy.</li>
@@ -764,6 +767,7 @@ Kubernetes Operators</h2>
 <li><a href="https://github.com/reactive-tech/kubegres" rel="nofollow">kubegres</a> - Kubegres is a Kubernetes operator allowing to deploy one or many clusters of PostgreSql instances and manage databases replication, failover and backup.</li>
 <li><a href="https://github.com/KubeOperator/KubeOperator" rel="nofollow">kubeoperator</a> - KubeOperator 是一个开源的轻量级 Kubernetes 发行版，专注于帮助企业规划、部署和运营生产级别的 K8s 集群。</li>
 <li><a href="https://github.com/kubevirt/kubevirt" rel="nofollow">kubevirt</a> - Kubernetes Virtualization Operator with API and runtime in order to define and manage virtual machines.</li>
+<li><a href="https://github.com/kubevirtbmc/kubevirtbmc" rel="nofollow">kubevirtbmc</a> - A Kubernetes operator of virtual BMCs that provide Redfish and IPMI services for KubeVirt virtual machines.</li>
 <li><a href="https://github.com/kudobuilder/kudo" rel="nofollow">kudo</a> - Kubernetes Universal Declarative Operator (KUDO).</li>
 <li><a href="https://github.com/operator-framework/operator-lifecycle-manager" rel="nofollow">operator-lifecycle-manager</a> - A management framework for extending Kubernetes with Operators.</li>
 <li><a href="https://github.com/operator-framework/operator-sdk" rel="nofollow">operator-sdk</a> - SDK for building Kubernetes applications. Provides high level APIs, useful abstractions, and project scaffolding.</li>
@@ -890,8 +894,8 @@ Security &amp; Compliance</h2>
 <li><a href="https://github.com/cedar-policy/cedar" rel="nofollow">cedar</a> - Core implementation of the Cedar language.</li>
 <li><a href="https://github.com/jetstack/cert-manager" rel="nofollow">cert-manager</a> - Automatically provision and manage TLS certificates in Kubernetes.</li>
 <li><a href="https://github.com/bridgecrewio/checkov/" rel="nofollow">checkov</a> - A static analysis tool for infrastructure as code - to prevent misconfigs at build time.</li>
-<li><a href="https://github.com/gebalamariusz/cloud-audit" rel="nofollow">cloud-audit</a> - Fast, opinionated AWS security scanner with 47 curated checks. Each finding includes copy-paste remediation in AWS CLI and Terraform. Features attack chain detection and a diff command for CI/CD pipeline gating.</li>
 <li><a href="https://github.com/quay/clair" rel="nofollow">clair</a> - Vulnerability Static Analysis for Containers.</li>
+<li><a href="https://github.com/gebalamariusz/cloud-audit" rel="nofollow">cloud-audit</a> - Fast, opinionated AWS security scanner with 47 curated checks. Each finding includes copy-paste remediation in AWS CLI and Terraform. Features attack chain detection and a diff command for CI/CD pipeline gating.</li>
 <li><a href="https://github.com/corazawaf/coraza" rel="nofollow">coraza</a> - OWASP Coraza WAF is a golang modsecurity compatible web application firewall library.</li>
 <li><a href="https://github.com/sigstore/cosign" rel="nofollow">cosign</a> - Container signing, verification, and provenance powered by Sigstore.</li>
 <li><a href="https://github.com/curiefense/curiefense" rel="nofollow">curiefense</a> - Adds a broad set of automated web security tools to Envoy.</li>
@@ -904,8 +908,8 @@ Security &amp; Compliance</h2>
 <li><a href="https://github.com/falcosecurity/falco" rel="nofollow">falco</a> - Behavioral Activity Monitoring With Container Support.</li>
 <li><a href="https://github.com/firezone/firezone" rel="nofollow">firezone</a> - VPN server and Linux firewall built on WireGuard®. Supports SSO, MFA, and user-scoped access rules.</li>
 <li><a href="https://github.com/HewlettPackard/galadriel" rel="nofollow">galadriel</a> - SPIFFE Federation the easy way.</li>
-<li><a href="https://github.com/Caiyeon/goldfish" rel="nofollow">goldfish</a> - A HashiCorp Vault UI panel written with VueJS and Vault native Go API.</li>
 <li><a href="https://github.com/stacklok/go-microvm" rel="nofollow">go-microvm</a> - Go framework for running OCI images as microVMs via libkrun with embedded runtime, rootfs management, and guest networking.</li>
+<li><a href="https://github.com/Caiyeon/goldfish" rel="nofollow">goldfish</a> - A HashiCorp Vault UI panel written with VueJS and Vault native Go API.</li>
 <li><a href="https://github.com/Grafeas/Grafeas" rel="nofollow">grafeas</a> - Cloud artifact metadata CRUD API and resource specifications.</li>
 <li><a href="https://github.com/anchore/grype" rel="nofollow">grype</a> - A vulnerability scanner for container images and filesystems.</li>
 <li><a href="https://github.com/appscode/guard" rel="nofollow">guard</a> - Kubernetes Authentication WebHook Server.</li>


### PR DESCRIPTION
Disclosure: I maintain [Attune](https://github.com/attune-io/attune).

Add Attune to **Cost & Governance**, alphabetically before `burn`. It is a Kubernetes operator that right-sizes pod CPU and memory in place from Prometheus usage, next to Karpenter, Escalator, and OpenCost.

- GitHub: https://github.com/attune-io/attune
- License: Apache-2.0
- Language: Go

This PR only changes `README.md`. `tmpl/index.html` is generated on the maintainer side.

Checks:

- `go test ./...` (`make test`)

Tracking: attune-io/attune#664
